### PR TITLE
Minor changes made for full demo creation

### DIFF
--- a/py_mimic_fhir/terminology.py
+++ b/py_mimic_fhir/terminology.py
@@ -122,6 +122,7 @@ def generate_valueset(mimic_valueset, db_conn, meta):
         valueset.compose = {'include': include_list}
     else:
         sys = {'system': f'{meta.base_url}/CodeSystem/{valueset.id}'}
+        valueset.compose = {'include': [sys]}
     return valueset
 
 

--- a/py_mimic_fhir/validate.py
+++ b/py_mimic_fhir/validate.py
@@ -94,6 +94,7 @@ def revalidate_bundle_from_file(err_filename, db_conn, margs):
 
     #make copy of file, since new errors will be written to the same file
     old_err_filename = f'{margs.err_path}{err_filename}'
+    logger.info(f'Error filename: {old_err_filename}')
     new_err_filename = f'{margs.err_path}rerun-{err_filename}'
     shutil.copy(old_err_filename, new_err_filename)
     os.remove(old_err_filename)

--- a/sql/fhir_observation_labevents.sql
+++ b/sql/fhir_observation_labevents.sql
@@ -124,7 +124,15 @@ SELECT
         , 'valueString', 
             CASE WHEN lab_VALUENUM IS NULL AND lab_VALUE IS NOT NULL THEN lab_VALUE 
                  WHEN lab_VALUENUM IS NULL AND lab_VALUE IS NULL THEN lab_COMMENTS                 
-            ELSE NULL END      
+            ELSE NULL END   
+        , 'dataAbsentReason', CASE WHEN lab_VALUENUM IS NULL AND lab_VALUE IS NULL AND lab_COMMENTS IS NULL THEN
+            jsonb_build_array(jsonb_build_object(
+                'coding', jsonb_build_array(jsonb_build_object(
+                    'system', 'http://terminology.hl7.org/CodeSystem/data-absent-reason'  
+                    , 'code', 'unknown'
+                ))
+            ))
+            ELSE NULL END
         , 'interpretation', 
             CASE WHEN lab_FLAG IS NOT NULL THEN
                 jsonb_build_array(jsonb_build_object(

--- a/tests/test_terminology.py
+++ b/tests/test_terminology.py
@@ -13,9 +13,7 @@ from fhir.resources.codesystem import CodeSystem, CodeSystemConcept
 from fhir.resources.valueset import ValueSet
 
 from py_mimic_fhir import db
-from py_mimic_fhir.lookup import (
-    MIMIC_CODESYSTEMS, MIMIC_VALUESETS, VALUESETS_CODED, VALUESETS_DOUBLE_SYSTEM
-)
+from py_mimic_fhir.lookup import (MIMIC_CODESYSTEMS, MIMIC_VALUESETS)
 
 
 def test_terminology_meta_data(db_conn):


### PR DESCRIPTION
Latest updates:
- Added `dataAbsentReason` to Observation_Labevents for the scenario where there is no `lab_value` or `lab_valuenum`
- Added case when to set dosageInstruction to NULL if no info is present in MedicationRequest and MedicationDispense
- Fixed valueset default creation, was not including system