### PR TITLE
Updating references to concept map valuesets

### DIFF
--- a/sql/codesystem/cs-admission-class.sql
+++ b/sql/codesystem/cs-admission-class.sql
@@ -1,5 +1,5 @@
 -- Admission class CodeSystem
--- Codes will need to be mapped to match US Core Act Encounter Code - http://terminology.hl7.org/CodeSystem/v3-ActCode
+-- Codes will need to be mapped to match US Core Act Encounter Code - http://terminology.hl7.org/ValueSet/v3-ActEncounterCode
 
 DROP TABLE IF EXISTS fhir_trm.cs_admission_class;
 CREATE TABLE fhir_trm.cs_admission_class(

--- a/sql/codesystem/cs-admission-type.sql
+++ b/sql/codesystem/cs-admission-type.sql
@@ -1,5 +1,5 @@
 -- Admission type CodeSystem
--- Codes will need to be mapped to match US Core Encounter Type -http://hl7.org/fhir/v3/ActPriority/vs.html
+-- Codes will need to be mapped to match US Core Encounter Type -http://hl7.org/fhir/ValueSet/encounter-type
 
 DROP TABLE IF EXISTS fhir_trm.cs_admission_type;
 CREATE TABLE fhir_trm.cs_admission_type(

--- a/sql/codesystem/cs-chartevents-d-items.sql
+++ b/sql/codesystem/cs-chartevents-d-items.sql
@@ -1,5 +1,5 @@
 -- Generate unique item codes for only the chartevents
--- This is pulled from the d-items CodeSystem
+-- This is pulled from the d-items CodeSystem, map to LOINC codes http://hl7.org/fhir/valueset-observation-codes.html
 
 
 DROP TABLE IF EXISTS fhir_trm.cs_chartevents_d_items;

--- a/sql/codesystem/cs-lab-fluid.sql
+++ b/sql/codesystem/cs-lab-fluid.sql
@@ -1,5 +1,5 @@
 -- Lab fluid CodeSystem
--- Codes will need to be mapped to something like the Specimen type example-v2 - http://hl7.org/fhir/v2/0487/index.html
+-- Codes will need to be mapped to something like the Specimen type example-v2 - http://terminology.hl7.org/ValueSet/v2-0487
 
 DROP TABLE IF EXISTS fhir_trm.cs_lab_fluid;
 CREATE TABLE fhir_trm.cs_lab_fluid(

--- a/sql/codesystem/cs-medication-frequency.sql
+++ b/sql/codesystem/cs-medication-frequency.sql
@@ -1,4 +1,5 @@
 -- Medication Frequency CodeSystem
+-- Map the frequency values to http://hl7.org/fhir/ValueSet/timing-abbreviation
 
 DROP TABLE IF EXISTS fhir_trm.cs_medication_frequency;
 CREATE TABLE fhir_trm.cs_medication_frequency(

--- a/sql/codesystem/cs-observation-category.sql
+++ b/sql/codesystem/cs-observation-category.sql
@@ -1,4 +1,5 @@
 -- Observation Category CodeSystem
+-- Map values to http://hl7.org/fhir/valueset-observation-category.html
 
 DROP TABLE IF EXISTS fhir_trm.cs_observation_category;
 CREATE TABLE fhir_trm.cs_observation_category(

--- a/sql/codesystem/cs-spec-type-desc.sql
+++ b/sql/codesystem/cs-spec-type-desc.sql
@@ -1,5 +1,5 @@
 -- Specimen type labs CodeSystem
--- Codes will need to be mapped to something like the Specimen type example-v2 - http://hl7.org/fhir/v2/0487/index.html
+-- Codes will need to be mapped to something like the Specimen type example-v2 - http://terminology.hl7.org/ValueSet/v2-0487
 
 DROP TABLE IF EXISTS fhir_trm.cs_spec_type_desc;
 CREATE TABLE fhir_trm.cs_spec_type_desc(


### PR DESCRIPTION
Documenting the concept maps that the MIMIC valuesets will be mapped to.

Minor update too: found that d-items CodeSystem was way larger than its usage, so trimmed it to just pull in procedureevents, datetimevents, and outputevents
- chartevents is too large so it needed its own CodeSystem
- inputevents is mapped to Medication