### PR TITLE
Full scale MIMIC in FHIR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,5 +135,6 @@ dmypy.json
 log/
 
 # Tutorial staging
-tutorial/staging
-tutorial/output
+tutorial/pathling/staging
+tutorial/hapi/database
+tutorial/pathling/output

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A version of MIMIC-IV-on-FHIR. The scripts and packages in the repository will generate the MIMIC-IV FHIR tables in PostgreSQL, validate in HAPI fhir, and export to ndjson. Before getting started make sure you have MIMIC-IV loaded into your local Postgres or follow this [MIMIC-IV guide](https://github.com/MIT-LCP/mimic-code/tree/main/mimic-iv/buildmimic/postgres) to set it up.
 
 ## Quickstart
-1. Clone the repository locally:
+1. Clone the repository locally:  
 ```sh
 git clone https://github.com/kind-lab/mimic-fhir.git
 ```

--- a/sql/codesystem/count_records_fhir_trm.sql
+++ b/sql/codesystem/count_records_fhir_trm.sql
@@ -1,0 +1,13 @@
+WITH tbl AS (
+    SELECT 
+        table_schema
+        , TABLE_NAME
+    FROM information_schema.tables
+    WHERE table_schema = 'fhir_trm'
+)
+SELECT 
+    table_schema
+    , TABLE_NAME
+    , (xpath('/row/c/text()', query_to_xml(format('select count(*) as c from %I.%I', table_schema, TABLE_NAME), FALSE, TRUE, '')))[1]::text::int AS rows_n
+FROM tbl
+ORDER BY table_name ASC;

--- a/sql/create_mimic_index.sql
+++ b/sql/create_mimic_index.sql
@@ -1,0 +1,9 @@
+DROP INDEX IF EXISTS labevents_idx02;
+CREATE INDEX labevents_idx02
+  ON mimic_hosp.labevents (specimen_id);
+  
+DROP INDEX IF EXISTS labevents_idx03;
+CREATE INDEX labevents_idx03
+  ON mimic_hosp.labevents (itemid);
+  
+  

--- a/sql/create_mimic_index.sql
+++ b/sql/create_mimic_index.sql
@@ -6,4 +6,29 @@ DROP INDEX IF EXISTS labevents_idx03;
 CREATE INDEX labevents_idx03
   ON mimic_hosp.labevents (itemid);
   
+DROP INDEX IF EXISTS d_labitems_idx01;
+CREATE INDEX d_labitems_idx01
+  ON mimic_hosp.d_labitems (itemid);
+  
+DROP INDEX IF EXISTS pharmacy_idx01;
+CREATE INDEX pharmacy_idx01
+  ON mimic_hosp.pharmacy (pharmacy_id);
+  
+  
+DROP INDEX IF EXISTS prescriptions_idx01;
+CREATE INDEX prescriptions_idx01
+  ON mimic_hosp.prescriptions (pharmacy_id);
+  
+  
+DROP INDEX IF EXISTS emar_idx01;
+CREATE INDEX emar_idx01
+  ON mimic_hosp.emar (pharmacy_id);
+  
+DROP INDEX IF EXISTS emar_idx02;
+CREATE INDEX emar_idx02
+  ON mimic_hosp.emar (poe_id);
+  
+DROP INDEX IF EXISTS poe_idx01;
+CREATE INDEX poe_idx01
+  ON mimic_hosp.poe (poe_id);
   

--- a/sql/fhir_condition.sql
+++ b/sql/fhir_condition.sql
@@ -27,8 +27,6 @@ WITH fhir_condition AS (
         , uuid_generate_v5(ns_encounter.uuid, CAST(diag.hadm_id AS TEXT)) as uuid_HADM_ID
     FROM
         mimic_hosp.diagnoses_icd diag
-        INNER JOIN fhir_etl.subjects sub
-            ON diag.subject_id =sub.subject_id 
         LEFT JOIN mimic_hosp.d_icd_diagnoses icd
             ON diag.icd_code = icd.icd_code
             AND diag.icd_version = icd.icd_version

--- a/sql/fhir_encounter.sql
+++ b/sql/fhir_encounter.sql
@@ -25,8 +25,6 @@ WITH transfer_locations AS (
         ORDER BY intime) AS location_array
     FROM 
         mimic_hosp.transfers tfr 
-        INNER JOIN fhir_etl.subjects sub
-            ON tfr.subject_id = sub.subject_id
         LEFT JOIN fhir_etl.uuid_namespace ns_location
             ON ns_location.name = 'Location'
     WHERE tfr.careunit IS NOT NULL 
@@ -45,8 +43,6 @@ WITH transfer_locations AS (
         ) AS cpt_ARRAY
     FROM 
         mimic_hosp.admissions adm
-        INNER JOIN fhir_etl.subjects sub
-            ON adm.subject_id = sub.subject_id 
         LEFT JOIN mimic_hosp.hcpcsevents cpt
             ON adm.hadm_id = cpt.hadm_id
     WHERE cpt.hcpcs_cd IS NOT NULL 
@@ -82,8 +78,6 @@ WITH transfer_locations AS (
         , uuid_generate_v5(ns_organization.uuid, 'http://hl7.org/fhir/sid/us-npi/1194052720') AS uuid_ORG
     FROM 
         mimic_hosp.admissions adm
-        INNER JOIN fhir_etl.subjects sub
-            ON adm.subject_id = sub.subject_id 
         LEFT JOIN transfer_locations tfr
             ON adm.hadm_id = tfr.hadm_id
         LEFT JOIN cpt_codes cpt

--- a/sql/fhir_encounter_icu.sql
+++ b/sql/fhir_encounter_icu.sql
@@ -19,8 +19,6 @@ WITH transfer_location AS (
         , min(icu.last_careunit) AS last_careunit
     FROM 
         mimic_icu.icustays icu
-        INNER JOIN fhir_etl.subjects sub
-            ON icu.subject_id = sub.subject_id 
         LEFT JOIN mimic_hosp.transfers tfr_first
             ON icu.hadm_id = tfr_first.hadm_id 
             AND icu.first_careunit = tfr_first.careunit 
@@ -53,10 +51,7 @@ WITH transfer_location AS (
         , uuid_generate_v5(ns_patient.uuid, CAST(icu.subject_id AS TEXT)) AS uuid_SUBJECT_ID
         
     FROM 
-        mimic_icu.icustays icu
-        INNER JOIN fhir_etl.subjects sub
-            ON icu.subject_id = sub.subject_id 
-        
+        mimic_icu.icustays icu        
         -- join transfers to get timing in each careunit
         LEFT JOIN transfer_location tfr
             ON icu.stay_id = tfr.stay_id

--- a/sql/fhir_medication_administration_icu.sql
+++ b/sql/fhir_medication_administration_icu.sql
@@ -29,8 +29,6 @@ WITH fhir_medication_administration_icu AS (
         , uuid_generate_v5(ns_encounter_icu.uuid, CAST(ie.stay_id AS TEXT)) AS uuid_STAY_ID
     FROM
         mimic_icu.inputevents ie
-        INNER JOIN fhir_etl.subjects sub
-            ON ie.subject_id = sub.subject_id 
         LEFT JOIN mimic_icu.d_items di
             ON ie.itemid = di.itemid
         LEFT JOIN fhir_etl.uuid_namespace ns_encounter_icu

--- a/sql/fhir_medication_dispense.sql
+++ b/sql/fhir_medication_dispense.sql
@@ -51,8 +51,6 @@ WITH distinct_prescriptions AS (
         , uuid_generate_v5(ns_encounter.uuid, CAST(ph.hadm_id AS TEXT)) AS uuid_HADM_ID
     FROM 
         mimic_hosp.pharmacy ph 
-        INNER JOIN fhir_etl.subjects sub 
-            ON ph.subject_id = sub.subject_id 
         LEFT JOIN distinct_prescriptions pr
             ON ph.pharmacy_id = pr.pharmacy_id
             
@@ -155,4 +153,3 @@ SELECT
     )) AS fhir  
 FROM 
     fhir_medication_dispense
-

--- a/sql/fhir_medication_request.sql
+++ b/sql/fhir_medication_request.sql
@@ -85,8 +85,6 @@ WITH prescript_request AS (
   	    prescript_request pr
   	    LEFT JOIN mimic_hosp.pharmacy ph
             ON pr.pharmacy_id = ph.pharmacy_id  
-  		INNER JOIN fhir_etl.subjects sub
-  			ON pr.subject_id = sub.subject_id 
   		LEFT JOIN fhir_etl.uuid_namespace ns_encounter
   			ON ns_encounter.name = 'Encounter'
   		LEFT JOIN fhir_etl.uuid_namespace ns_patient
@@ -245,8 +243,6 @@ WITH prescriptions AS (
         poe_medreq pm
         INNER JOIN mimic_hosp.poe poe
             ON pm.poe_id = poe.poe_id
-        INNER JOIN fhir_etl.subjects sub
-            ON poe.subject_id = sub.subject_id 
         
         -- uuid namespaces
         LEFT JOIN fhir_etl.uuid_namespace ns_encounter

--- a/sql/fhir_observation_chartevents.sql
+++ b/sql/fhir_observation_chartevents.sql
@@ -29,8 +29,6 @@ WITH fhir_observation_ce as (
         , uuid_generate_v5(ns_encounter_icu.uuid, CAST(ce.stay_id AS text)) AS uuid_STAY_ID
     FROM
         mimic_icu.chartevents ce
-        INNER JOIN fhir_etl.subjects sub
-            ON ce.subject_id = sub.subject_id
         LEFT JOIN mimic_icu.d_items di
             ON ce.itemid = di.itemid
         LEFT JOIN fhir_etl.uuid_namespace ns_encounter_icu
@@ -39,6 +37,9 @@ WITH fhir_observation_ce as (
             ON ns_patient.name = 'Patient'
         LEFT JOIN fhir_etl.uuid_namespace ns_observation_ce
             ON ns_observation_ce.name = 'ObservationChartevents'
+    WHERE   
+        -- filter out the one duplicate value (one patient at one charttime)
+        ((stay_id = 34934165) AND (charttime = '2151-10-03 05:14:00.000')) = FALSE
 )
 INSERT INTO mimic_fhir.observation_chartevents
 SELECT 

--- a/sql/fhir_observation_datetimeevents.sql
+++ b/sql/fhir_observation_datetimeevents.sql
@@ -24,8 +24,6 @@ WITH fhir_observation_de AS (
         , uuid_generate_v5(ns_encounter_icu.uuid, CAST(de.stay_id AS TEXT)) AS uuid_STAY_ID
     FROM
         mimic_icu.datetimeevents de
-        INNER JOIN fhir_etl.subjects sub
-            ON de.subject_id =sub.subject_id
         LEFT JOIN mimic_icu.d_items di
             ON de.itemid = di.itemid
         LEFT JOIN fhir_etl.uuid_namespace ns_encounter_icu

--- a/sql/fhir_observation_labevents.sql
+++ b/sql/fhir_observation_labevents.sql
@@ -28,6 +28,7 @@ WITH fhir_observation_labevents AS (
         -- Parse values with a comparator and pulling out numeric value
         , CASE 
             WHEN lab.valuenum IS NOT NULL THEN lab.valuenum
+            WHEN value IN  ('<1/HPF', '<1>50', '<A', '>1.035 REFRACTOMETER', '>1.035 REFRA', '150>', '>1.035€') THEN NULL --only entry that does not fit in here 
             WHEN value LIKE '%<=%' THEN CAST(split_part(lab.value,'<=',2) AS NUMERIC)
             WHEN value LIKE '%<%' THEN CAST(split_part(lab.value,'<',2) AS NUMERIC)
             WHEN value LIKE '%>=%' THEN CAST(split_part(lab.value,'>=',2) AS NUMERIC)

--- a/sql/fhir_observation_labevents.sql
+++ b/sql/fhir_observation_labevents.sql
@@ -28,7 +28,9 @@ WITH fhir_observation_labevents AS (
         -- Parse values with a comparator and pulling out numeric value
         , CASE 
             WHEN lab.valuenum IS NOT NULL THEN lab.valuenum
-            WHEN value IN  ('<1/HPF', '<1>50', '<A', '>1.035 REFRACTOMETER', '>1.035 REFRA', '150>', '>1.035€') THEN NULL --only entry that does not fit in here 
+            WHEN value IN  ('<1>50', '150>') THEN NULL --UNIQUE entries that are invalid
+            WHEN value ~ '[a-zA-Z]' THEN NULL -- If any letters are found in the value COLUMN (about )
+            WHEN value ~ '[^\x00-\x7F]' THEN NULL -- FOR unicode char that ARE IN the value COLUMN (about 4 values)
             WHEN value LIKE '%<=%' THEN CAST(split_part(lab.value,'<=',2) AS NUMERIC)
             WHEN value LIKE '%<%' THEN CAST(split_part(lab.value,'<',2) AS NUMERIC)
             WHEN value LIKE '%>=%' THEN CAST(split_part(lab.value,'>=',2) AS NUMERIC)
@@ -60,8 +62,6 @@ WITH fhir_observation_labevents AS (
         , uuid_generate_v5(ns_specimen.uuid, CAST(lab.specimen_id AS TEXT)) AS uuid_SPECIMEN_ID
     FROM
         mimic_hosp.labevents lab
-        INNER JOIN fhir_etl.subjects sub
-            ON lab.subject_id =sub.subject_id 
         LEFT JOIN mimic_hosp.d_labitems dlab
             ON lab.itemid = dlab.itemid                             
         LEFT JOIN fhir_etl.uuid_namespace ns_encounter

--- a/sql/fhir_observation_micro_org.sql
+++ b/sql/fhir_observation_micro_org.sql
@@ -31,8 +31,6 @@ WITH micro_info AS (
             END as fhir_SUSCEPTIBILITY
     FROM 
         mimic_hosp.microbiologyevents mi
-        INNER JOIN fhir_etl.subjects sub
-            ON mi.subject_id = sub.subject_id
         LEFT JOIN fhir_etl.uuid_namespace ns_observation_micro_susc
             ON ns_observation_micro_susc.name = 'ObservationMicroSusc'
     WHERE

--- a/sql/fhir_observation_micro_org.sql
+++ b/sql/fhir_observation_micro_org.sql
@@ -24,11 +24,8 @@ WITH micro_info AS (
         , CASE WHEN MIN(mi.ab_itemid) IS NULL THEN NULL
             ELSE 
                 jsonb_agg(
-                    jsonb_build_object('reference', 'Observation/' || uuid_generate_v5(ns_observation_micro_susc.uuid, 
-                                            mi.micro_specimen_id || '-' ||
-                                            mi.org_itemid || '-' ||
-                                            mi.isolate_num || '-' ||
-                                            mi.ab_itemid)
+                    jsonb_build_object(
+                        'reference', 'Observation/' || uuid_generate_v5(ns_observation_micro_susc.uuid, CAST(mi.microevent_id AS TEXT))
                     ) 
                 )
             END as fhir_SUSCEPTIBILITY

--- a/sql/fhir_observation_micro_susc.sql
+++ b/sql/fhir_observation_micro_susc.sql
@@ -31,8 +31,6 @@ WITH fhir_observation_micro_susc AS (
         , uuid_generate_v5(ns_patient.uuid, CAST(mi.subject_id AS TEXT)) as uuid_SUBJECT_ID 
     FROM 
         mimic_hosp.microbiologyevents mi
-        INNER JOIN fhir_etl.subjects sub
-            ON mi.subject_id = sub.subject_id 
         LEFT JOIN fhir_etl.uuid_namespace ns_patient
             ON ns_patient.name = 'Patient'
         LEFT JOIN fhir_etl.uuid_namespace ns_observation_micro_org

--- a/sql/fhir_observation_micro_susc.sql
+++ b/sql/fhir_observation_micro_susc.sql
@@ -8,8 +8,7 @@ CREATE TABLE mimic_fhir.observation_micro_susc(
 WITH fhir_observation_micro_susc AS (
     SELECT
         mi.micro_specimen_id  AS mi_MICRO_SPECIMEN_ID
-        , mi.micro_specimen_id || '-' ||  mi.org_itemid || '-' ||  
-            mi.isolate_num || '-' ||  mi.ab_itemid AS id_MICRO_SUSC
+        , CAST(mi.microevent_id AS TEXT) AS id_MICRO_SUSC
         , CAST(mi.ab_itemid AS TEXT) AS mi_AB_ITEMID
         , mi.ab_name AS mi_AB_NAME
         , mi.subject_id AS mi_SUBJECT_ID
@@ -27,11 +26,7 @@ WITH fhir_observation_micro_susc AS (
         AS mi_DILUTION_COMPARISON
 
         -- UUID references
-        , uuid_generate_v5(
-            ns_observation_micro_susc.uuid 
-            , mi.micro_specimen_id || '-' ||  mi.org_itemid || '-' ||
-                mi.isolate_num || '-' ||  mi.ab_itemid
-        ) AS uuid_MICRO_SUSC
+        , uuid_generate_v5(ns_observation_micro_susc.uuid, CAST(mi.microevent_id AS TEXT)) AS uuid_MICRO_SUSC
         , uuid_generate_v5(ns_observation_micro_org.uuid, mi.test_itemid || '-' || mi.micro_specimen_id || '-' || mi.org_itemid) AS uuid_MICRO_ORG
         , uuid_generate_v5(ns_patient.uuid, CAST(mi.subject_id AS TEXT)) as uuid_SUBJECT_ID 
     FROM 

--- a/sql/fhir_observation_micro_test.sql
+++ b/sql/fhir_observation_micro_test.sql
@@ -44,8 +44,6 @@ WITH distinct_org AS (
         
     FROM 
         mimic_hosp.microbiologyevents mi
-        INNER JOIN fhir_etl.subjects sub    
-            ON mi.subject_id = sub.subject_id 
     GROUP BY 
         test_itemid
         , micro_specimen_id

--- a/sql/fhir_observation_outputevents.sql
+++ b/sql/fhir_observation_outputevents.sql
@@ -25,8 +25,6 @@ WITH fhir_observation_oe AS (
         , uuid_generate_v5(ns_encounter_icu.uuid, CAST(oe.stay_id AS TEXT)) AS uuid_STAY_ID
     FROM
         mimic_icu.outputevents oe
-        INNER JOIN fhir_etl.subjects sub
-            ON oe.subject_id = sub.subject_id
         LEFT JOIN mimic_icu.d_items di
             ON oe.itemid = di.itemid
         LEFT JOIN fhir_etl.uuid_namespace ns_encounter_icu

--- a/sql/fhir_patient.sql
+++ b/sql/fhir_patient.sql
@@ -18,8 +18,6 @@ WITH tb_admissions AS (
         , MIN(adm.language) AS adm_LANGUAGE
     FROM  
         mimic_hosp.patients pat
-        INNER JOIN fhir_etl.subjects sub
-            ON pat.subject_id = sub.subject_id 
         INNER JOIN mimic_hosp.transfers tfs
             ON pat.subject_id = tfs.subject_id
         -- Grab latest admittime to get the latest demographic info 
@@ -51,8 +49,6 @@ WITH tb_admissions AS (
         , uuid_generate_v5(ns_organization.uuid, 'http://hl7.org/fhir/sid/us-npi/1194052720') AS  UUID_organization
     FROM  
         mimic_hosp.patients pat
-        INNER JOIN fhir_etl.subjects sub
-            ON pat.subject_id = sub.subject_id  
         LEFT JOIN tb_admissions adm
             ON pat.subject_id = adm.subject_id
         LEFT JOIN fhir_etl.uuid_namespace ns_patient

--- a/sql/fhir_procedure.sql
+++ b/sql/fhir_procedure.sql
@@ -26,8 +26,6 @@ WITH fhir_procedure AS (
         , uuid_generate_v5(ns_encounter.uuid, CAST(proc.hadm_id AS TEXT)) AS uuid_HADM_ID
     FROM
         mimic_hosp.procedures_icd proc
-        INNER JOIN fhir_etl.subjects sub
-            ON proc.subject_id = sub.subject_id 
         LEFT JOIN mimic_hosp.d_icd_procedures icd
             ON proc.icd_code = icd.icd_code
             AND proc.icd_version = icd.icd_version

--- a/sql/fhir_procedure_icu.sql
+++ b/sql/fhir_procedure_icu.sql
@@ -25,8 +25,6 @@ WITH fhir_procedure_icu AS (
         , uuid_generate_v5(ns_encounter_icu.uuid, CAST(pe.stay_id AS TEXT)) AS uuid_STAY_ID
     FROM
         mimic_icu.procedureevents pe
-        INNER JOIN fhir_etl.subjects sub
-            ON pe.subject_id = sub.subject_id
         LEFT JOIN mimic_icu.d_items di
             ON pe.itemid = di.itemid
         LEFT JOIN fhir_etl.map_status_procedure_icu map_status

--- a/sql/fhir_specimen.sql
+++ b/sql/fhir_specimen.sql
@@ -19,8 +19,6 @@ WITH fhir_specimen AS (
         , uuid_generate_v5(ns_patient.uuid, CAST(MAX(mi.subject_id) AS TEXT)) as uuid_SUBJECT_ID
     FROM
         mimic_hosp.microbiologyevents mi
-        INNER JOIN fhir_etl.subjects sub
-            ON mi.subject_id = sub.subject_id
         LEFT JOIN fhir_etl.uuid_namespace ns_patient
             ON ns_patient.name = 'Patient'
         LEFT JOIN fhir_etl.uuid_namespace ns_specimen

--- a/sql/fhir_specimen_lab.sql
+++ b/sql/fhir_specimen_lab.sql
@@ -6,28 +6,36 @@ CREATE TABLE mimic_fhir.specimen_lab(
 );
 
 -- Lab specimen
-WITH fhir_specimen_lab AS (
-    SELECT
-        CAST(lab.specimen_id AS TEXT) AS lab_SPECIMEN_ID
-        , CAST(MAX(lab.charttime) AS TIMESTAMPTZ) AS lab_CHARTTIME
-        , MAX(dlab.fluid) AS dlab_FLUID
-
-        , uuid_generate_v5(ns_specimen.uuid, CAST(lab.specimen_id AS TEXT)) AS uuid_SPECIMEN
-        , uuid_generate_v5(ns_patient.uuid, CAST(MAX(lab.subject_id) AS TEXT)) as uuid_SUBJECT_ID
+WITH lab AS (
+    SELECT 
+        lab.specimen_id
+        , MAX(lab.itemid) AS itemid
+        , MAX(lab.subject_id) AS subject_id
+        , MAX(lab.charttime) AS charttime
     FROM 
         mimic_hosp.labevents lab
         INNER JOIN fhir_etl.subjects sub
-            ON lab.subject_id = sub.subject_id
+            ON lab.subject_id = sub.subject_id    
+    GROUP BY
+        specimen_id        
+)
+, fhir_specimen_lab AS (
+    SELECT
+        CAST(lab.specimen_id AS TEXT) AS lab_SPECIMEN_ID
+        , CAST(lab.charttime AS TIMESTAMPTZ) AS lab_CHARTTIME
+        , dlab.fluid AS dlab_FLUID
+
+        , uuid_generate_v5(ns_specimen.uuid, CAST(lab.specimen_id AS TEXT)) AS uuid_SPECIMEN
+        , uuid_generate_v5(ns_patient.uuid, CAST(lab.subject_id AS TEXT)) as uuid_SUBJECT_ID
+    FROM 
+        lab
         LEFT JOIN mimic_hosp.d_labitems dlab
             ON lab.itemid = dlab.itemid
         LEFT JOIN fhir_etl.uuid_namespace ns_patient
             ON ns_patient.name = 'Patient'
         LEFT JOIN fhir_etl.uuid_namespace ns_specimen
             ON ns_specimen.name = 'SpecimenLab'
-    GROUP BY
-        specimen_id
-        , ns_specimen.uuid
-        , ns_patient.uuid
+    
 )  
   
 INSERT INTO mimic_fhir.specimen_lab

--- a/sql/fhir_specimen_lab.sql
+++ b/sql/fhir_specimen_lab.sql
@@ -13,9 +13,7 @@ WITH lab AS (
         , MAX(lab.subject_id) AS subject_id
         , MAX(lab.charttime) AS charttime
     FROM 
-        mimic_hosp.labevents lab
-        INNER JOIN fhir_etl.subjects sub
-            ON lab.subject_id = sub.subject_id    
+        mimic_hosp.labevents lab  
     GROUP BY
         specimen_id        
 )


### PR DESCRIPTION
Scripts have been updated to allow for full MIMIC to be translated into FHIR. A few notes:
- Specimen was running very slow, was optimized to run faster
- labevents value column had a lot of non-numeric entries that needed to be filtered out
- duplicate rows were handled in emar_detail and chartevents