### PR TITLE
Test row counts

### DIFF
--- a/sql/fhir_observation_micro_susc.sql
+++ b/sql/fhir_observation_micro_susc.sql
@@ -82,7 +82,17 @@ SELECT
             'coding', jsonb_build_array(jsonb_build_object(
                 'system', 'http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation'  
                 , 'code', interp_FHIR_INTERPRETATION_CODE
-                , 'display', interp_FHIR_INTERPRETATION_DISPLAY    WHERE lab.labevent_id < 1000000tails'
+                , 'display', interp_FHIR_INTERPRETATION_DISPLAY
+            ))
+        )
+        , 'derivedFrom', jsonb_build_array(jsonb_build_object('reference', 'Observation/' || uuid_MICRO_ORG)) 
+        , 'note', jsonb_build_array(jsonb_build_object(
+            'text',  mi_COMMENTS
+        ))
+        , 'extension', CASE
+            WHEN mi_DILUTION_COMPARISON IS NOT NULL THEN
+                jsonb_build_array(jsonb_build_object(
+                    'url', 'http://fhir.mimic.mit.edu/StructureDefinition/dilution-details'
                     , 'valueQuantity', jsonb_build_object(
                         'value', mi_DILUTION_VALUE
                         , 'comparator', mi_DILUTION_COMPARISON

--- a/tests/test_mimic_fhir_row_count.sql
+++ b/tests/test_mimic_fhir_row_count.sql
@@ -1,0 +1,39 @@
+WITH table_counts AS
+(
+    SELECT COUNT(*) AS n_row_observed,    5006884 AS n_row_expected, 'condition' AS table_name FROM mimic_fhir.condition UNION ALL
+    SELECT COUNT(*) AS n_row_observed,     946692 AS n_row_expected, 'condition_ed' AS table_name FROM mimic_fhir.condition_ed UNION ALL
+    SELECT COUNT(*) AS n_row_observed,     454324 AS n_row_expected, 'encounter' AS table_name FROM mimic_fhir.encounter UNION ALL
+    SELECT COUNT(*) AS n_row_observed,     447712 AS n_row_expected, 'encounter_ed' AS table_name FROM mimic_fhir.encounter_ed UNION ALL
+    SELECT COUNT(*) AS n_row_observed,      76943 AS n_row_expected, 'encounter_icu' AS table_name FROM mimic_fhir.encounter_icu UNION ALL
+    SELECT COUNT(*) AS n_row_observed,         39 AS n_row_expected, 'location' AS table_name FROM mimic_fhir.location UNION ALL
+    SELECT COUNT(*) AS n_row_observed,      20075 AS n_row_expected, 'medication' AS table_name FROM mimic_fhir.medication UNION ALL
+    SELECT COUNT(*) AS n_row_observed,   29128087 AS n_row_expected, 'medication_administration' AS table_name FROM mimic_fhir.medication_administration UNION ALL
+    SELECT COUNT(*) AS n_row_observed,    9442345 AS n_row_expected, 'medication_administration_icu' AS table_name FROM mimic_fhir.medication_administration_icu UNION ALL
+    SELECT COUNT(*) AS n_row_observed,   13350281 AS n_row_expected, 'medication_dispense' AS table_name FROM mimic_fhir.medication_dispense UNION ALL
+    SELECT COUNT(*) AS n_row_observed,    1670590 AS n_row_expected, 'medication_dispense_ed' AS table_name FROM mimic_fhir.medication_dispense_ed UNION ALL
+    SELECT COUNT(*) AS n_row_observed,       6461 AS n_row_expected, 'medication_mix' AS table_name FROM mimic_fhir.medication_mix UNION ALL
+    SELECT COUNT(*) AS n_row_observed,   16217713 AS n_row_expected, 'medication_request' AS table_name FROM mimic_fhir.medication_request UNION ALL
+    SELECT COUNT(*) AS n_row_observed,    2733573 AS n_row_expected, 'medication_statement_ed' AS table_name FROM mimic_fhir.medication_statement_ed UNION ALL
+    SELECT COUNT(*) AS n_row_observed,    7477876 AS n_row_expected, 'observation_datetimeevents' AS table_name FROM mimic_fhir.observation_datetimeevents UNION ALL
+    SELECT COUNT(*) AS n_row_observed,    4637088 AS n_row_expected, 'observation_ed' AS table_name FROM mimic_fhir.observation_ed UNION ALL
+    SELECT COUNT(*) AS n_row_observed,     304527 AS n_row_expected, 'observation_micro_org' AS table_name FROM mimic_fhir.observation_micro_org UNION ALL
+    SELECT COUNT(*) AS n_row_observed,    1163623 AS n_row_expected, 'observation_micro_susc' AS table_name FROM mimic_fhir.observation_micro_susc UNION ALL
+    SELECT COUNT(*) AS n_row_observed,    2297709 AS n_row_expected, 'observation_micro_test' AS table_name FROM mimic_fhir.observation_micro_test UNION ALL
+    SELECT COUNT(*) AS n_row_observed,    4450049 AS n_row_expected, 'observation_outputevents' AS table_name FROM mimic_fhir.observation_outputevents UNION ALL
+    SELECT COUNT(*) AS n_row_observed,   10473440 AS n_row_expected, 'observation_vital_signs' AS table_name FROM mimic_fhir.observation_vital_signs UNION ALL
+    SELECT COUNT(*) AS n_row_observed,          1 AS n_row_expected, 'organization' AS table_name FROM mimic_fhir.organization UNION ALL
+    SELECT COUNT(*) AS n_row_observed,     315460 AS n_row_expected, 'patient' AS table_name FROM mimic_fhir.patient UNION ALL
+    SELECT COUNT(*) AS n_row_observed,     704124 AS n_row_expected, 'procedure' AS table_name FROM mimic_fhir.procedure UNION ALL
+    SELECT COUNT(*) AS n_row_observed,    2094688 AS n_row_expected, 'procedure_ed' AS table_name FROM mimic_fhir.procedure_ed UNION ALL
+    SELECT COUNT(*) AS n_row_observed,     731788 AS n_row_expected, 'procedure_icu' AS table_name FROM mimic_fhir.procedure_icu UNION ALL
+    SELECT COUNT(*) AS n_row_observed,    1670188 AS n_row_expected, 'specimen' AS table_name FROM mimic_fhir.specimen UNION ALL
+    SELECT COUNT(*) AS n_row_observed,   14081306 AS n_row_expected, 'specimen_lab' AS table_name FROM mimic_fhir.specimen_lab
+    -- below are the two largest tables by an order of magnitude
+    -- commenting them out reduces query time from ~10 minutes to just ~1 minute
+    SELECT COUNT(*) AS n_row_observed, 124342638 AS n_row_expected, 'observation_labevents' AS table_name FROM mimic_fhir.observation_labevents UNION ALL
+    SELECT COUNT(*) AS n_row_observed, 329822254 AS n_row_expected, 'observation_chartevents' AS table_name FROM mimic_fhir.observation_chartevents UNION ALL
+)
+SELECT table_name, n_row_expected, n_row_observed
+, CASE WHEN n_row_observed = n_row_expected THEN 'PASS' ELSE 'FAIL' END AS test_status
+FROM table_counts
+ORDER BY table_name;

--- a/tests/test_mimic_fhir_row_count.sql
+++ b/tests/test_mimic_fhir_row_count.sql
@@ -1,37 +1,37 @@
 WITH table_counts AS
 (
-    SELECT COUNT(*) AS n_row_observed,    5006884 AS n_row_expected, 'condition' AS table_name FROM mimic_fhir.condition UNION ALL
-    SELECT COUNT(*) AS n_row_observed,     946692 AS n_row_expected, 'condition_ed' AS table_name FROM mimic_fhir.condition_ed UNION ALL
-    SELECT COUNT(*) AS n_row_observed,     454324 AS n_row_expected, 'encounter' AS table_name FROM mimic_fhir.encounter UNION ALL
-    SELECT COUNT(*) AS n_row_observed,     447712 AS n_row_expected, 'encounter_ed' AS table_name FROM mimic_fhir.encounter_ed UNION ALL
-    SELECT COUNT(*) AS n_row_observed,      76943 AS n_row_expected, 'encounter_icu' AS table_name FROM mimic_fhir.encounter_icu UNION ALL
-    SELECT COUNT(*) AS n_row_observed,         39 AS n_row_expected, 'location' AS table_name FROM mimic_fhir.location UNION ALL
-    SELECT COUNT(*) AS n_row_observed,      20075 AS n_row_expected, 'medication' AS table_name FROM mimic_fhir.medication UNION ALL
-    SELECT COUNT(*) AS n_row_observed,   29128087 AS n_row_expected, 'medication_administration' AS table_name FROM mimic_fhir.medication_administration UNION ALL
-    SELECT COUNT(*) AS n_row_observed,    9442345 AS n_row_expected, 'medication_administration_icu' AS table_name FROM mimic_fhir.medication_administration_icu UNION ALL
-    SELECT COUNT(*) AS n_row_observed,   13350281 AS n_row_expected, 'medication_dispense' AS table_name FROM mimic_fhir.medication_dispense UNION ALL
-    SELECT COUNT(*) AS n_row_observed,    1670590 AS n_row_expected, 'medication_dispense_ed' AS table_name FROM mimic_fhir.medication_dispense_ed UNION ALL
-    SELECT COUNT(*) AS n_row_observed,       6461 AS n_row_expected, 'medication_mix' AS table_name FROM mimic_fhir.medication_mix UNION ALL
-    SELECT COUNT(*) AS n_row_observed,   16217713 AS n_row_expected, 'medication_request' AS table_name FROM mimic_fhir.medication_request UNION ALL
-    SELECT COUNT(*) AS n_row_observed,    2733573 AS n_row_expected, 'medication_statement_ed' AS table_name FROM mimic_fhir.medication_statement_ed UNION ALL
-    SELECT COUNT(*) AS n_row_observed,    7477876 AS n_row_expected, 'observation_datetimeevents' AS table_name FROM mimic_fhir.observation_datetimeevents UNION ALL
-    SELECT COUNT(*) AS n_row_observed,    4637088 AS n_row_expected, 'observation_ed' AS table_name FROM mimic_fhir.observation_ed UNION ALL
-    SELECT COUNT(*) AS n_row_observed,     304527 AS n_row_expected, 'observation_micro_org' AS table_name FROM mimic_fhir.observation_micro_org UNION ALL
-    SELECT COUNT(*) AS n_row_observed,    1163623 AS n_row_expected, 'observation_micro_susc' AS table_name FROM mimic_fhir.observation_micro_susc UNION ALL
-    SELECT COUNT(*) AS n_row_observed,    2297709 AS n_row_expected, 'observation_micro_test' AS table_name FROM mimic_fhir.observation_micro_test UNION ALL
-    SELECT COUNT(*) AS n_row_observed,    4450049 AS n_row_expected, 'observation_outputevents' AS table_name FROM mimic_fhir.observation_outputevents UNION ALL
-    SELECT COUNT(*) AS n_row_observed,   10473440 AS n_row_expected, 'observation_vital_signs' AS table_name FROM mimic_fhir.observation_vital_signs UNION ALL
-    SELECT COUNT(*) AS n_row_observed,          1 AS n_row_expected, 'organization' AS table_name FROM mimic_fhir.organization UNION ALL
-    SELECT COUNT(*) AS n_row_observed,     315460 AS n_row_expected, 'patient' AS table_name FROM mimic_fhir.patient UNION ALL
-    SELECT COUNT(*) AS n_row_observed,     704124 AS n_row_expected, 'procedure' AS table_name FROM mimic_fhir.procedure UNION ALL
-    SELECT COUNT(*) AS n_row_observed,    2094688 AS n_row_expected, 'procedure_ed' AS table_name FROM mimic_fhir.procedure_ed UNION ALL
-    SELECT COUNT(*) AS n_row_observed,     731788 AS n_row_expected, 'procedure_icu' AS table_name FROM mimic_fhir.procedure_icu UNION ALL
-    SELECT COUNT(*) AS n_row_observed,    1670188 AS n_row_expected, 'specimen' AS table_name FROM mimic_fhir.specimen UNION ALL
-    SELECT COUNT(*) AS n_row_observed,   14081306 AS n_row_expected, 'specimen_lab' AS table_name FROM mimic_fhir.specimen_lab
+              SELECT COUNT(*) AS n_row_observed,    5006884 AS n_row_expected, 'condition' AS table_name FROM mimic_fhir.condition
+    UNION ALL SELECT COUNT(*) AS n_row_observed,     946692 AS n_row_expected, 'condition_ed' AS table_name FROM mimic_fhir.condition_ed
+    UNION ALL SELECT COUNT(*) AS n_row_observed,     454324 AS n_row_expected, 'encounter' AS table_name FROM mimic_fhir.encounter
+    UNION ALL SELECT COUNT(*) AS n_row_observed,     447712 AS n_row_expected, 'encounter_ed' AS table_name FROM mimic_fhir.encounter_ed
+    UNION ALL SELECT COUNT(*) AS n_row_observed,      76943 AS n_row_expected, 'encounter_icu' AS table_name FROM mimic_fhir.encounter_icu
+    UNION ALL SELECT COUNT(*) AS n_row_observed,         39 AS n_row_expected, 'location' AS table_name FROM mimic_fhir.location
+    UNION ALL SELECT COUNT(*) AS n_row_observed,      20075 AS n_row_expected, 'medication' AS table_name FROM mimic_fhir.medication
+    UNION ALL SELECT COUNT(*) AS n_row_observed,   29128087 AS n_row_expected, 'medication_administration' AS table_name FROM mimic_fhir.medication_administration
+    UNION ALL SELECT COUNT(*) AS n_row_observed,    9442345 AS n_row_expected, 'medication_administration_icu' AS table_name FROM mimic_fhir.medication_administration_icu
+    UNION ALL SELECT COUNT(*) AS n_row_observed,   13350281 AS n_row_expected, 'medication_dispense' AS table_name FROM mimic_fhir.medication_dispense
+    UNION ALL SELECT COUNT(*) AS n_row_observed,    1670590 AS n_row_expected, 'medication_dispense_ed' AS table_name FROM mimic_fhir.medication_dispense_ed
+    UNION ALL SELECT COUNT(*) AS n_row_observed,       6461 AS n_row_expected, 'medication_mix' AS table_name FROM mimic_fhir.medication_mix
+    UNION ALL SELECT COUNT(*) AS n_row_observed,   16217713 AS n_row_expected, 'medication_request' AS table_name FROM mimic_fhir.medication_request
+    UNION ALL SELECT COUNT(*) AS n_row_observed,    2733573 AS n_row_expected, 'medication_statement_ed' AS table_name FROM mimic_fhir.medication_statement_ed
+    UNION ALL SELECT COUNT(*) AS n_row_observed,    7477876 AS n_row_expected, 'observation_datetimeevents' AS table_name FROM mimic_fhir.observation_datetimeevents
+    UNION ALL SELECT COUNT(*) AS n_row_observed,    4637088 AS n_row_expected, 'observation_ed' AS table_name FROM mimic_fhir.observation_ed
+    UNION ALL SELECT COUNT(*) AS n_row_observed,     304527 AS n_row_expected, 'observation_micro_org' AS table_name FROM mimic_fhir.observation_micro_org
+    UNION ALL SELECT COUNT(*) AS n_row_observed,    1163623 AS n_row_expected, 'observation_micro_susc' AS table_name FROM mimic_fhir.observation_micro_susc
+    UNION ALL SELECT COUNT(*) AS n_row_observed,    2297709 AS n_row_expected, 'observation_micro_test' AS table_name FROM mimic_fhir.observation_micro_test
+    UNION ALL SELECT COUNT(*) AS n_row_observed,    4450049 AS n_row_expected, 'observation_outputevents' AS table_name FROM mimic_fhir.observation_outputevents
+    UNION ALL SELECT COUNT(*) AS n_row_observed,   10473440 AS n_row_expected, 'observation_vital_signs' AS table_name FROM mimic_fhir.observation_vital_signs
+    UNION ALL SELECT COUNT(*) AS n_row_observed,          1 AS n_row_expected, 'organization' AS table_name FROM mimic_fhir.organization
+    UNION ALL SELECT COUNT(*) AS n_row_observed,     315460 AS n_row_expected, 'patient' AS table_name FROM mimic_fhir.patient
+    UNION ALL SELECT COUNT(*) AS n_row_observed,     704124 AS n_row_expected, 'procedure' AS table_name FROM mimic_fhir.procedure
+    UNION ALL SELECT COUNT(*) AS n_row_observed,    2094688 AS n_row_expected, 'procedure_ed' AS table_name FROM mimic_fhir.procedure_ed
+    UNION ALL SELECT COUNT(*) AS n_row_observed,     731788 AS n_row_expected, 'procedure_icu' AS table_name FROM mimic_fhir.procedure_icu
+    UNION ALL SELECT COUNT(*) AS n_row_observed,    1670188 AS n_row_expected, 'specimen' AS table_name FROM mimic_fhir.specimen
+    UNION ALL SELECT COUNT(*) AS n_row_observed,   14081306 AS n_row_expected, 'specimen_lab' AS table_name FROM mimic_fhir.specimen_lab
     -- below are the two largest tables by an order of magnitude
     -- commenting them out reduces query time from ~10 minutes to just ~1 minute
-    SELECT COUNT(*) AS n_row_observed, 124342638 AS n_row_expected, 'observation_labevents' AS table_name FROM mimic_fhir.observation_labevents UNION ALL
-    SELECT COUNT(*) AS n_row_observed, 329822254 AS n_row_expected, 'observation_chartevents' AS table_name FROM mimic_fhir.observation_chartevents UNION ALL
+    UNION ALL SELECT COUNT(*) AS n_row_observed, 124342638 AS n_row_expected, 'observation_labevents' AS table_name FROM mimic_fhir.observation_labevents
+    UNION ALL SELECT COUNT(*) AS n_row_observed, 329822254 AS n_row_expected, 'observation_chartevents' AS table_name FROM mimic_fhir.observation_chartevents
 )
 SELECT table_name, n_row_expected, n_row_observed
 , CASE WHEN n_row_observed = n_row_expected THEN 'PASS' ELSE 'FAIL' END AS test_status

--- a/tests/test_mimic_fhir_row_count_approximate.sql
+++ b/tests/test_mimic_fhir_row_count_approximate.sql
@@ -1,0 +1,49 @@
+WITH expected_counts AS
+( 
+    SELECT   5006884 AS n_row_expected, 'condition' AS table_name UNION ALL
+    SELECT    946692 AS n_row_expected, 'condition_ed' AS table_name  UNION ALL
+    SELECT    454324 AS n_row_expected, 'encounter' AS table_name  UNION ALL
+    SELECT    447712 AS n_row_expected, 'encounter_ed' AS table_name  UNION ALL
+    SELECT     76943 AS n_row_expected, 'encounter_icu' AS table_name  UNION ALL
+    SELECT        39 AS n_row_expected, 'location' AS table_name  UNION ALL
+    SELECT     20075 AS n_row_expected, 'medication' AS table_name  UNION ALL
+    SELECT  29128087 AS n_row_expected, 'medication_administration' AS table_name  UNION ALL
+    SELECT   9442345 AS n_row_expected, 'medication_administration_icu' AS table_name  UNION ALL
+    SELECT  13350281 AS n_row_expected, 'medication_dispense' AS table_name  UNION ALL
+    SELECT   1670590 AS n_row_expected, 'medication_dispense_ed' AS table_name  UNION ALL
+    SELECT      6461 AS n_row_expected, 'medication_mix' AS table_name  UNION ALL
+    SELECT  16217713 AS n_row_expected, 'medication_request' AS table_name  UNION ALL
+    SELECT   2733573 AS n_row_expected, 'medication_statement_ed' AS table_name  UNION ALL
+    SELECT   7477876 AS n_row_expected, 'observation_datetimeevents' AS table_name  UNION ALL
+    SELECT   4637088 AS n_row_expected, 'observation_ed' AS table_name  UNION ALL
+    SELECT    304527 AS n_row_expected, 'observation_micro_org' AS table_name  UNION ALL
+    SELECT   1163623 AS n_row_expected, 'observation_micro_susc' AS table_name  UNION ALL
+    SELECT   2297709 AS n_row_expected, 'observation_micro_test' AS table_name  UNION ALL
+    SELECT   4450049 AS n_row_expected, 'observation_outputevents' AS table_name  UNION ALL
+    SELECT  10473440 AS n_row_expected, 'observation_vital_signs' AS table_name  UNION ALL
+    SELECT         1 AS n_row_expected, 'organization' AS table_name  UNION ALL
+    SELECT    315460 AS n_row_expected, 'patient' AS table_name  UNION ALL
+    SELECT    704124 AS n_row_expected, 'procedure' AS table_name  UNION ALL
+    SELECT   2094688 AS n_row_expected, 'procedure_ed' AS table_name  UNION ALL
+    SELECT    731788 AS n_row_expected, 'procedure_icu' AS table_name  UNION ALL
+    SELECT   1670188 AS n_row_expected, 'specimen' AS table_name  UNION ALL
+    SELECT  14081306 AS n_row_expected, 'specimen_lab' AS table_name  UNION ALL
+    SELECT 124342638 AS n_row_expected, 'observation_labevents' AS table_name UNION ALL
+    SELECT 329822254 AS n_row_expected, 'observation_chartevents' AS table_name
+)
+-- TODO: deal with small tables
+SELECT c.relname AS table_name
+-- for smaller tables, we do an exact count
+, CASE
+    WHEN c.relname = 'location' THEN (SELECT COUNT(*) FROM mimic_fhir.location)
+    WHEN c.relname = 'organization' THEN (SELECT COUNT(*) FROM mimic_fhir.organization)
+    -- approximate estimate is c.reltuples
+    ELSE CAST(c.reltuples AS INTEGER) AS n_row_estimate
+, e.n_row_expected
+, CASE
+    WHEN c.reltuples BETWEEN (0.97*n_row_expected) AND (1.03*n_row_expected) THEN 'PASS'
+ELSE 'FAIL' END AS test_status
+FROM pg_class c
+INNER JOIN expected_counts e
+ON c.relname = e.table_name
+ORDER BY table_name;

--- a/tests/test_mimic_fhir_row_count_approximate.sql
+++ b/tests/test_mimic_fhir_row_count_approximate.sql
@@ -1,35 +1,35 @@
 WITH expected_counts AS
 ( 
-    SELECT   5006884 AS n_row_expected, 'condition' AS table_name UNION ALL
-    SELECT    946692 AS n_row_expected, 'condition_ed' AS table_name  UNION ALL
-    SELECT    454324 AS n_row_expected, 'encounter' AS table_name  UNION ALL
-    SELECT    447712 AS n_row_expected, 'encounter_ed' AS table_name  UNION ALL
-    SELECT     76943 AS n_row_expected, 'encounter_icu' AS table_name  UNION ALL
-    SELECT        39 AS n_row_expected, 'location' AS table_name  UNION ALL
-    SELECT     20075 AS n_row_expected, 'medication' AS table_name  UNION ALL
-    SELECT  29128087 AS n_row_expected, 'medication_administration' AS table_name  UNION ALL
-    SELECT   9442345 AS n_row_expected, 'medication_administration_icu' AS table_name  UNION ALL
-    SELECT  13350281 AS n_row_expected, 'medication_dispense' AS table_name  UNION ALL
-    SELECT   1670590 AS n_row_expected, 'medication_dispense_ed' AS table_name  UNION ALL
-    SELECT      6461 AS n_row_expected, 'medication_mix' AS table_name  UNION ALL
-    SELECT  16217713 AS n_row_expected, 'medication_request' AS table_name  UNION ALL
-    SELECT   2733573 AS n_row_expected, 'medication_statement_ed' AS table_name  UNION ALL
-    SELECT   7477876 AS n_row_expected, 'observation_datetimeevents' AS table_name  UNION ALL
-    SELECT   4637088 AS n_row_expected, 'observation_ed' AS table_name  UNION ALL
-    SELECT    304527 AS n_row_expected, 'observation_micro_org' AS table_name  UNION ALL
-    SELECT   1163623 AS n_row_expected, 'observation_micro_susc' AS table_name  UNION ALL
-    SELECT   2297709 AS n_row_expected, 'observation_micro_test' AS table_name  UNION ALL
-    SELECT   4450049 AS n_row_expected, 'observation_outputevents' AS table_name  UNION ALL
-    SELECT  10473440 AS n_row_expected, 'observation_vital_signs' AS table_name  UNION ALL
-    SELECT         1 AS n_row_expected, 'organization' AS table_name  UNION ALL
-    SELECT    315460 AS n_row_expected, 'patient' AS table_name  UNION ALL
-    SELECT    704124 AS n_row_expected, 'procedure' AS table_name  UNION ALL
-    SELECT   2094688 AS n_row_expected, 'procedure_ed' AS table_name  UNION ALL
-    SELECT    731788 AS n_row_expected, 'procedure_icu' AS table_name  UNION ALL
-    SELECT   1670188 AS n_row_expected, 'specimen' AS table_name  UNION ALL
-    SELECT  14081306 AS n_row_expected, 'specimen_lab' AS table_name  UNION ALL
-    SELECT 124342638 AS n_row_expected, 'observation_labevents' AS table_name UNION ALL
-    SELECT 329822254 AS n_row_expected, 'observation_chartevents' AS table_name
+              SELECT   5006884 AS n_row_expected, 'condition' AS table_name
+    UNION ALL SELECT    946692 AS n_row_expected, 'condition_ed' AS table_name
+    UNION ALL SELECT    454324 AS n_row_expected, 'encounter' AS table_name
+    UNION ALL SELECT    447712 AS n_row_expected, 'encounter_ed' AS table_name
+    UNION ALL SELECT     76943 AS n_row_expected, 'encounter_icu' AS table_name
+    UNION ALL SELECT        39 AS n_row_expected, 'location' AS table_name
+    UNION ALL SELECT     20075 AS n_row_expected, 'medication' AS table_name
+    UNION ALL SELECT  29128087 AS n_row_expected, 'medication_administration' AS table_name
+    UNION ALL SELECT   9442345 AS n_row_expected, 'medication_administration_icu' AS table_name
+    UNION ALL SELECT  13350281 AS n_row_expected, 'medication_dispense' AS table_name
+    UNION ALL SELECT   1670590 AS n_row_expected, 'medication_dispense_ed' AS table_name
+    UNION ALL SELECT      6461 AS n_row_expected, 'medication_mix' AS table_name
+    UNION ALL SELECT  16217713 AS n_row_expected, 'medication_request' AS table_name
+    UNION ALL SELECT   2733573 AS n_row_expected, 'medication_statement_ed' AS table_name
+    UNION ALL SELECT   7477876 AS n_row_expected, 'observation_datetimeevents' AS table_name
+    UNION ALL SELECT   4637088 AS n_row_expected, 'observation_ed' AS table_name
+    UNION ALL SELECT    304527 AS n_row_expected, 'observation_micro_org' AS table_name
+    UNION ALL SELECT   1163623 AS n_row_expected, 'observation_micro_susc' AS table_name
+    UNION ALL SELECT   2297709 AS n_row_expected, 'observation_micro_test' AS table_name
+    UNION ALL SELECT   4450049 AS n_row_expected, 'observation_outputevents' AS table_name
+    UNION ALL SELECT  10473440 AS n_row_expected, 'observation_vital_signs' AS table_name
+    UNION ALL SELECT         1 AS n_row_expected, 'organization' AS table_name
+    UNION ALL SELECT    315460 AS n_row_expected, 'patient' AS table_name
+    UNION ALL SELECT    704124 AS n_row_expected, 'procedure' AS table_name
+    UNION ALL SELECT   2094688 AS n_row_expected, 'procedure_ed' AS table_name
+    UNION ALL SELECT    731788 AS n_row_expected, 'procedure_icu' AS table_name
+    UNION ALL SELECT   1670188 AS n_row_expected, 'specimen' AS table_name
+    UNION ALL SELECT  14081306 AS n_row_expected, 'specimen_lab' AS table_name
+    UNION ALL SELECT 124342638 AS n_row_expected, 'observation_labevents' AS table_name
+    UNION ALL SELECT 329822254 AS n_row_expected, 'observation_chartevents' AS table_name
 )
 -- TODO: deal with small tables
 SELECT c.relname AS table_name
@@ -38,7 +38,8 @@ SELECT c.relname AS table_name
     WHEN c.relname = 'location' THEN (SELECT COUNT(*) FROM mimic_fhir.location)
     WHEN c.relname = 'organization' THEN (SELECT COUNT(*) FROM mimic_fhir.organization)
     -- approximate estimate is c.reltuples
-    ELSE CAST(c.reltuples AS INTEGER) AS n_row_estimate
+    ELSE CAST(c.reltuples AS INTEGER)
+END AS n_row_estimate
 , e.n_row_expected
 , CASE
     WHEN c.reltuples BETWEEN (0.97*n_row_expected) AND (1.03*n_row_expected) THEN 'PASS'


### PR DESCRIPTION
Add an SQL script to verify row counts in the mimic_fhir table for MIMIC-IV v2.0. @alexmbennett2 if you have a copy, give them a whirl. Might be worth incorporating the SQL into a python based test so it's checked with pytest (but maybe only the approximate one, as the exact is very slow).