### PR TITLE
Load BigQuery with data and validate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,9 @@ export DBNAME_HAPI="hapi_r4"
 export DBHOST="localhost"
 export PGPORT=5432
 
+# DB MODE is either POSTGRES or BIGQUERY
+export DB_MODE=POSTGRES
+
 # FHIR Server Setup
 export FHIR_SERVER="http://localhost:8080/fhir/"
 export MIMIC_TERMINOLOGY_PATH="/path/to/terminology/mimic-profiles/input/resources/"

--- a/environment.yml
+++ b/environment.yml
@@ -14,8 +14,13 @@ dependencies:
   - requests
   - tqdm
   - yapf
+  - google-cloud-storage
   - pip
   - pip:
     - python-dotenv
-    - pytest-order
     - fhir.resources
+    - google-cloud-bigquery
+    - google-cloud-pubsub
+    - google-api-python-client
+    - pandas-gbq
+    - google-auth

--- a/gcp/bigquery/postgres_to_bq/bq_create_fhir_tables.sql
+++ b/gcp/bigquery/postgres_to_bq/bq_create_fhir_tables.sql
@@ -1,0 +1,214 @@
+DROP TABLE IF EXISTS mimic_fhir.patient;
+CREATE TABLE mimic_fhir.patient (
+  id STRING(36),
+  fhir STRING
+);
+
+-- DATA TABLES
+DROP TABLE IF EXISTS mimic_fhir.location;
+CREATE TABLE mimic_fhir.location (
+  id STRING(36),
+  fhir STRING
+);
+
+DROP TABLE IF EXISTS mimic_fhir.medication;
+CREATE TABLE mimic_fhir.medication (
+  id STRING(36),
+  fhir STRING
+);
+
+DROP TABLE IF EXISTS mimic_fhir.medication_mix;
+CREATE TABLE mimic_fhir.medication_mix (
+  id STRING(36),
+  fhir STRING
+);
+
+DROP TABLE IF EXISTS mimic_fhir.organization;
+CREATE TABLE mimic_fhir.organization (
+  id STRING(36),
+  fhir STRING
+);
+
+
+-- PATIENT TABLES
+
+DROP TABLE IF EXISTS mimic_fhir.condition;
+CREATE TABLE mimic_fhir.condition (
+  id STRING(36),
+  patient_id STRING(36),
+  fhir STRING
+);
+
+DROP TABLE IF EXISTS mimic_fhir.condition_ed;
+CREATE TABLE mimic_fhir.condition_ed (
+  id STRING(36),
+  patient_id STRING(36),
+  fhir STRING
+);
+
+DROP TABLE IF EXISTS mimic_fhir.encounter;
+CREATE TABLE mimic_fhir.encounter (
+  id STRING(36),
+  patient_id STRING(36),
+  fhir STRING
+);
+
+DROP TABLE IF EXISTS mimic_fhir.encounter_ed;
+CREATE TABLE mimic_fhir.encounter_ed (
+  id STRING(36),
+  patient_id STRING(36),
+  fhir STRING
+);
+
+DROP TABLE IF EXISTS mimic_fhir.encounter_icu;
+CREATE TABLE mimic_fhir.encounter_icu (
+  id STRING(36),
+  patient_id STRING(36),
+  fhir STRING
+);
+
+
+DROP TABLE IF EXISTS mimic_fhir.medication_administration;
+CREATE TABLE mimic_fhir.medication_administration (
+  id STRING(36),
+  patient_id STRING(36),
+  fhir STRING
+);
+
+DROP TABLE IF EXISTS mimic_fhir.medication_administration_icu;
+CREATE TABLE mimic_fhir.medication_administration_icu (
+  id STRING(36),
+  patient_id STRING(36),
+  fhir STRING
+);
+
+DROP TABLE IF EXISTS mimic_fhir.medication_dispense;
+CREATE TABLE mimic_fhir.medication_dispense (
+  id STRING(36),
+  patient_id STRING(36),
+  fhir STRING
+);
+
+DROP TABLE IF EXISTS mimic_fhir.medication_dispense_ed;
+CREATE TABLE mimic_fhir.medication_dispense_ed (
+  id STRING(36),
+  patient_id STRING(36),
+  fhir STRING
+);
+
+
+
+
+DROP TABLE IF EXISTS mimic_fhir.medication_request;
+CREATE TABLE mimic_fhir.medication_request (
+  id STRING(36),
+  patient_id STRING(36),
+  fhir STRING
+);
+
+DROP TABLE IF EXISTS mimic_fhir.medication_statement_ed;
+CREATE TABLE mimic_fhir.medication_statement_ed (
+  id STRING(36),
+  patient_id STRING(36),
+  fhir STRING
+);
+
+DROP TABLE IF EXISTS mimic_fhir.observation_chartevents;
+CREATE TABLE mimic_fhir.observation_chartevents (
+  id STRING(36),
+  patient_id STRING(36),
+  fhir STRING
+);
+
+DROP TABLE IF EXISTS mimic_fhir.observation_datetimeevents;
+CREATE TABLE mimic_fhir.observation_datetimeevents (
+  id STRING(36),
+  patient_id STRING(36),
+  fhir STRING
+);
+
+DROP TABLE IF EXISTS mimic_fhir.observation_ed;
+CREATE TABLE mimic_fhir.observation_ed (
+  id STRING(36),
+  patient_id STRING(36),
+  fhir STRING
+);
+
+DROP TABLE IF EXISTS mimic_fhir.observation_labevents;
+CREATE TABLE mimic_fhir.observation_labevents (
+  id STRING(36),
+  patient_id STRING(36),
+  fhir STRING
+);
+
+DROP TABLE IF EXISTS mimic_fhir.observation_micro_org;
+CREATE TABLE mimic_fhir.observation_micro_org (
+  id STRING(36),
+  patient_id STRING(36),
+  fhir STRING
+);
+
+DROP TABLE IF EXISTS mimic_fhir.observation_micro_test;
+CREATE TABLE mimic_fhir.observation_micro_test (
+  id STRING(36),
+  patient_id STRING(36),
+  fhir STRING
+);
+
+DROP TABLE IF EXISTS mimic_fhir.observation_micro_susc;
+CREATE TABLE mimic_fhir.observation_micro_susc (
+  id STRING(36),
+  patient_id STRING(36),
+  fhir STRING
+);
+
+DROP TABLE IF EXISTS mimic_fhir.observation_outputevents;
+CREATE TABLE mimic_fhir.observation_outputevents (
+  id STRING(36),
+  patient_id STRING(36),
+  fhir STRING
+);
+
+DROP TABLE IF EXISTS mimic_fhir.observation_vital_signs;
+CREATE TABLE mimic_fhir.observation_vital_signs (
+  id STRING(36),
+  patient_id STRING(36),
+  fhir STRING
+);
+
+
+
+DROP TABLE IF EXISTS mimic_fhir.procedure;
+CREATE TABLE mimic_fhir.procedure (
+  id STRING(36),
+  patient_id STRING(36),
+  fhir STRING
+);
+
+DROP TABLE IF EXISTS mimic_fhir.procedure_ed;
+CREATE TABLE mimic_fhir.procedure_ed (
+  id STRING(36),
+  patient_id STRING(36),
+  fhir STRING
+);
+
+DROP TABLE IF EXISTS mimic_fhir.procedure_icu;
+CREATE TABLE mimic_fhir.procedure_icu (
+  id STRING(36),
+  patient_id STRING(36),
+  fhir STRING
+);
+
+DROP TABLE IF EXISTS mimic_fhir.specimen;
+CREATE TABLE mimic_fhir.specimen (
+  id STRING(36),
+  patient_id STRING(36),
+  fhir STRING
+);
+
+DROP TABLE IF EXISTS mimic_fhir.specimen_lab;
+CREATE TABLE mimic_fhir.specimen_lab (
+  id STRING(36),
+  patient_id STRING(36),
+  fhir STRING
+);

--- a/gcp/bigquery/postgres_to_bq/bq_load_fhir_tables.sh
+++ b/gcp/bigquery/postgres_to_bq/bq_load_fhir_tables.sh
@@ -1,0 +1,13 @@
+declare -a FhirTables=("patient" "condition" "condition_ed" "encounter" "encounter_ed" "encounter_icu"
+                       "location" "medication" "medication_administration" "medication_administration_icu"
+                       "medication_dispense" "medication_dispense_ed" "medication_mix" "medication_request"
+                       "medication_statement_ed" "observation_chartevents" "observation_datetimeevents"
+                       "observation_ed" "observation_labevents" "observation_micro_org" "observation_micro_susc"
+                       "observation_micro_test" "observation_outputevents" "observation_vital_signs" 
+                       "procedure" "procedure_ed" "procedure_ed" "procedure_icu" "specimen" "specimen_lab")
+
+
+for table in ${FhirTables[@]}; do
+    echo Loading $table table
+    bq load --source_format=CSV mimic_fhir.$table $GS_CSV_PATH/$table.csv
+done

--- a/gcp/bigquery/postgres_to_bq/psql_export_fhir_to_csv.sql
+++ b/gcp/bigquery/postgres_to_bq/psql_export_fhir_to_csv.sql
@@ -1,0 +1,122 @@
+
+-- :output_dir is set in the initial psql command. Ensure '--set output_dir=$OUTPUT_DIR' is included
+
+\echo patient
+\set outputcsv '\'' :output_dir 'patient.csv' '\''
+COPY mimic_fhir.patient TO :outputcsv CSV;
+
+\echo condition
+\set outputcsv '\'' :output_dir 'condition.csv' '\''
+COPY mimic_fhir.condition TO :outputcsv CSV;
+
+\echo condition_ed
+\set outputcsv '\'' :output_dir 'condition_ed.csv' '\''
+COPY mimic_fhir.condition_ed TO :outputcsv CSV;
+
+\echo encounter
+\set outputcsv '\'' :output_dir 'encounter.csv' '\''
+COPY mimic_fhir.encounter TO :outputcsv CSV;
+
+\echo encounter_ed
+\set outputcsv '\'' :output_dir 'encounter_ed.csv' '\''
+COPY mimic_fhir.encounter_ed TO :outputcsv CSV;
+
+\echo encounter_icu
+\set outputcsv '\'' :output_dir 'encounter_icu.csv' '\''
+COPY mimic_fhir.encounter_icu TO :outputcsv CSV;
+
+\echo location
+\set outputcsv '\'' :output_dir 'location.csv' '\''
+COPY mimic_fhir.location TO :outputcsv CSV;
+
+\echo medication
+\set outputcsv '\'' :output_dir 'medication.csv' '\''
+COPY mimic_fhir.medication TO :outputcsv CSV;
+
+\echo medication_administration
+\set outputcsv '\'' :output_dir 'medication_administration.csv' '\''
+COPY mimic_fhir.medication_administration TO :outputcsv CSV;
+
+\echo medication_administration_icu
+\set outputcsv '\'' :output_dir 'medication_administration_icu.csv' '\''
+COPY mimic_fhir.medication_administration_icu TO :outputcsv CSV;
+
+\echo medication_dispense
+\set outputcsv '\'' :output_dir 'medication_dispense.csv' '\''
+COPY mimic_fhir.medication_dispense TO :outputcsv CSV;
+
+\echo medication_dispense_ed
+\set outputcsv '\'' :output_dir 'medication_dispense_ed.csv' '\''
+COPY mimic_fhir.medication_dispense_ed TO :outputcsv CSV;
+
+\echo medication_mix
+\set outputcsv '\'' :output_dir 'medication_mix.csv' '\''
+COPY mimic_fhir.medication_mix TO :outputcsv CSV;
+
+\echo medication_request
+\set outputcsv '\'' :output_dir 'medication_request.csv' '\''
+COPY mimic_fhir.medication_request TO :outputcsv CSV;
+
+\echo medication_statement_ed
+\set outputcsv '\'' :output_dir 'medication_statement_ed.csv' '\''
+COPY mimic_fhir.medication_statement_ed TO :outputcsv CSV;
+
+\echo observation_chartevents
+\set outputcsv '\'' :output_dir 'observation_chartevents.csv' '\''
+COPY mimic_fhir.observation_chartevents TO :outputcsv CSV;
+
+\echo observation_datetimeevents
+\set outputcsv '\'' :output_dir 'observation_datetimeevents.csv' '\''
+COPY mimic_fhir.observation_datetimeevents TO :outputcsv CSV;
+
+\echo observation_ed
+\set outputcsv '\'' :output_dir 'observation_ed.csv' '\''
+COPY mimic_fhir.observation_ed TO :outputcsv CSV;
+
+\echo observation_labevents
+\set outputcsv '\'' :output_dir 'observation_labevents.csv' '\''
+COPY mimic_fhir.observation_labevents TO :outputcsv CSV;
+
+\echo observation_micro_org
+\set outputcsv '\'' :output_dir 'observation_micro_org.csv' '\''
+COPY mimic_fhir.observation_micro_org TO :outputcsv CSV;
+
+\echo observation_micro_test
+\set outputcsv '\'' :output_dir 'observation_micro_test.csv' '\''
+COPY mimic_fhir.observation_micro_test TO :outputcsv CSV;
+
+\echo observation_micro_susc
+\set outputcsv '\'' :output_dir 'observation_micro_susc.csv' '\''
+COPY mimic_fhir.observation_micro_susc TO :outputcsv CSV;
+
+\echo observation_outputevents
+\set outputcsv '\'' :output_dir 'observation_outputevents.csv' '\''
+COPY mimic_fhir.observation_outputevents TO :outputcsv CSV;
+
+\echo observation_vital_signs
+\set outputcsv '\'' :output_dir 'observation_vital_signs.csv' '\''
+COPY mimic_fhir.observation_vital_signs TO :outputcsv CSV;
+
+\echo organization
+\set outputcsv '\'' :output_dir 'organization.csv' '\''
+COPY mimic_fhir.organization TO :outputcsv CSV;
+
+\echo procedure
+\set outputcsv '\'' :output_dir 'procedure.csv' '\''
+COPY mimic_fhir.procedure TO :outputcsv CSV;
+
+\echo procedure_ed
+\set outputcsv '\'' :output_dir 'procedure_ed.csv' '\''
+COPY mimic_fhir.procedure_ed TO :outputcsv CSV;
+
+\echo procedure_icu
+\set outputcsv '\'' :output_dir 'procedure_icu.csv' '\''
+COPY mimic_fhir.procedure_icu TO :outputcsv CSV;
+
+\echo specimen
+\set outputcsv '\'' :output_dir 'specimen.csv' '\''
+COPY mimic_fhir.specimen TO :outputcsv CSV;
+
+\echo specimen_lab
+\set outputcsv '\'' :output_dir 'specimen_lab.csv' '\''
+COPY mimic_fhir.specimen_lab TO :outputcsv CSV;

--- a/py_mimic_fhir/__main__.py
+++ b/py_mimic_fhir/__main__.py
@@ -162,6 +162,14 @@ def parse_arguments(arguments=None):
         required=True
     )
 
+    parser.add_argument(
+        '--db_mode',
+        action=EnvDefault,
+        envvar='DB_MODE',
+        help='Database mode, either Postgres or BigQuery',
+        required=True
+    )
+
     # Create subparsers for validation, export, and terminology
     subparsers = parser.add_subparsers(dest="actions", title="actions")
     subparsers.required = True
@@ -344,7 +352,7 @@ def validate(args, gcp_args):
 # Export all resources from FHIR Server and write to NDJSON
 def export(args, gcp_args):
     db_conn = connect_db(
-        args.sqluser, args.sqlpass, args.dbname_mimic, args.host
+        args.sqluser, args.sqlpass, args.dbname_mimic, args.host, args.db_mode
     )
     pe_args = PatientEverythingArgs(
         args.patient_bundle, args.num_patients, args.resource_types,

--- a/py_mimic_fhir/db.py
+++ b/py_mimic_fhir/db.py
@@ -1,18 +1,24 @@
 import psycopg2
 import logging
+import json
 import pandas as pd
+import pandas_gbq as pdq
+import google.auth
 
 
 # database connection
-def connect_db(sqluser, sqlpass, dbname, host):
-    sqluser = sqluser
-    sqlpass = sqlpass
-    dbname = dbname
-    host = host
-
-    connection = psycopg2.connect(
-        dbname=dbname, user=sqluser, password=sqlpass, host=host
-    )
+def connect_db(sqluser, sqlpass, dbname, host, db_mode):
+    if db_mode == 'POSTGRES':
+        connection = psycopg2.connect(
+            dbname=dbname, user=sqluser, password=sqlpass, host=host
+        )
+    elif db_mode == 'BIGQUERY':
+        credentials, project = google.auth.default()
+        pdq.context.credentials = credentials
+        pdq.context.project = project
+        connection = db_mode
+    else:
+        connection = db_mode
     return connection
 
 
@@ -21,9 +27,20 @@ def connect_db(sqluser, sqlpass, dbname, host):
 #---------------------------------------------------------
 
 
+def db_read_query(query, db_conn):
+    if db_conn == 'BIGQUERY':
+        df = pdq.read_gbq(query)
+        if 'fhir' in df.columns:
+            df['fhir'] = df['fhir'].apply(json.loads)
+    else:
+        df = pd.read_sql_query(query, db_conn)
+
+    return df
+
+
 def get_table(db_conn, schema, table):
     q_table = f"SELECT * FROM {schema}.{table};"
-    df_table = pd.read_sql_query(q_table, db_conn)
+    df_table = db_read_query(q_table, db_conn)
     return df_table
 
 
@@ -38,7 +55,7 @@ def get_resources_by_pat(db_conn, table_name, patient_id):
         SELECT fhir FROM mimic_fhir.{table_name}
         WHERE {id_field} = '{patient_id}'
     """
-    pd_resources = pd.read_sql_query(q_resource, db_conn)
+    pd_resources = db_read_query(q_resource, db_conn)
     resources = pd_resources.fhir.to_list()
 
     return resources
@@ -47,7 +64,7 @@ def get_resources_by_pat(db_conn, table_name, patient_id):
 # Generic function to get single resource from the DB
 def get_patient_resource(db_conn, patient_id):
     q_resource = f"SELECT * FROM mimic_fhir.patient WHERE id='{patient_id}'"
-    resource = pd.read_sql_query(q_resource, db_conn)
+    resource = db_read_query(q_resource, db_conn)
 
     return resource.fhir[0]
 
@@ -55,14 +72,14 @@ def get_patient_resource(db_conn, patient_id):
 # Get any resource by its id
 def get_resource_by_id(db_conn, profile, profile_id):
     q_resource = f"SELECT * FROM mimic_fhir.{profile} WHERE id='{profile_id}'"
-    resource = pd.read_sql_query(q_resource, db_conn)
+    resource = db_read_query(q_resource, db_conn)
 
     return resource.fhir[0]
 
 
 def get_n_patient_id(db_conn, n_patient):
     q_resource = f"SELECT * FROM mimic_fhir.patient LIMIT {n_patient}"
-    resource = pd.read_sql_query(q_resource, db_conn)
+    resource = db_read_query(q_resource, db_conn)
     patient_ids = [fhir['id'] for fhir in resource.fhir]
 
     return patient_ids
@@ -73,7 +90,7 @@ def get_n_resources(db_conn, table, n_limit=0):
         q_resource = f"SELECT * FROM mimic_fhir.{table}"
     else:
         q_resource = f"SELECT * FROM mimic_fhir.{table} LIMIT {n_limit}"
-    resource = pd.read_sql_query(q_resource, db_conn)
+    resource = db_read_query(q_resource, db_conn)
 
     resources = []
     [resources.append(fhir) for fhir in resource.fhir]
@@ -93,5 +110,5 @@ def get_pat_id_with_links(db_conn, resource_list):
         """
     q_resource = f'{q_resource} LIMIT 20;'
 
-    resource = pd.read_sql_query(q_resource, db_conn)
+    resource = db_read_query(q_resource, db_conn)
     return resource.fhir[0]['id']

--- a/py_mimic_fhir/terminology.py
+++ b/py_mimic_fhir/terminology.py
@@ -40,7 +40,7 @@ class TerminologyMetaData():
 # Master terminology function. Creates all CodeSystems and ValueSets
 def generate_all_terminology(args):
     db_conn = connect_db(
-        args.sqluser, args.sqlpass, args.dbname_mimic, args.host
+        args.sqluser, args.sqlpass, args.dbname_mimic, args.host, args_db_mode
     )
     meta = TerminologyMetaData(db_conn, args.version, args.status)
     generate_codesystems(db_conn, meta, args.terminology_path)

--- a/py_mimic_fhir/validate.py
+++ b/py_mimic_fhir/validate.py
@@ -28,7 +28,7 @@ def multiprocess_validate(args, margs, gcp_args):
     logger.info(f'num workers: {num_workers}')
 
     db_conn = connect_db(
-        args.sqluser, args.sqlpass, args.dbname_mimic, args.host
+        args.sqluser, args.sqlpass, args.dbname_mimic, args.host, args.db_mode
     )
 
     if args.init:
@@ -63,7 +63,8 @@ def validation_worker(patient_id, args, margs, gcp_args):
         response_list = [False]
 
         db_conn = connect_db(
-            args.sqluser, args.sqlpass, args.dbname_mimic, args.host
+            args.sqluser, args.sqlpass, args.dbname_mimic, args.host,
+            args.db_mode
         )
         response_list = validate_all_bundles(
             patient_id, db_conn, margs, gcp_args
@@ -81,7 +82,7 @@ def validation_worker(patient_id, args, margs, gcp_args):
 def validate_n_patients(args, margs, gcp_args):
     # initialize db connection
     db_conn = connect_db(
-        args.sqluser, args.sqlpass, args.dbname_mimic, args.host
+        args.sqluser, args.sqlpass, args.dbname_mimic, args.host, args.db_mode
     )
 
     if args.init:
@@ -160,7 +161,7 @@ def revalidate_bad_bundles(args, margs):
     day_of_week = datetime.now().strftime('%A').lower()
     err_filename = f'err-bundles-{day_of_week}.json'
     db_conn = connect_db(
-        args.sqluser, args.sqlpass, args.dbname_mimic, args.host
+        args.sqluser, args.sqlpass, args.dbname_mimic, args.host, args.db_mode
     )
 
     response_list = revalidate_bundle_from_file(err_filename, db_conn, margs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import os
 import tkinter as tk
 import pytest
 
-from py_mimic_fhir.db import get_n_resources, connect_db
+from py_mimic_fhir.db import get_n_resources, connect_db, db_read_query
 import py_mimic_fhir.terminology as trm
 from py_mimic_fhir.config import MimicArgs, GoogleArgs, PatientEverythingArgs
 
@@ -18,6 +18,7 @@ SQLUSER = os.getenv('SQLUSER')
 SQLPASS = os.getenv('SQLPASS')
 DBNAME_MIMIC = os.getenv('DBNAME_MIMIC')
 DBNAME_HAPI = os.getenv('DBNAME_HAPI')
+DB_MODE = os.getenv('DB_MODE')
 HOST = os.getenv('DBHOST')
 TERMINOLOGY_PATH = os.getenv('MIMIC_TERMINOLOGY_PATH')
 FHIR_SERVER = os.getenv('FHIR_SERVER')
@@ -86,7 +87,7 @@ def validator():
 # Initialize database connection to mimic
 @pytest.fixture(scope="session")
 def db_conn():
-    conn = connect_db(SQLUSER, SQLPASS, DBNAME_MIMIC, HOST)
+    conn = connect_db(SQLUSER, SQLPASS, DBNAME_MIMIC, HOST, DB_MODE)
     return conn
 
 
@@ -158,7 +159,7 @@ def initialize_single_resource(validator, db_conn, table_name):
 # Generic function to get single resource from the DB
 def get_single_resource(db_conn, table_name):
     q_resource = f"SELECT * FROM mimic_fhir.{table_name} LIMIT 1"
-    resource = pd.read_sql_query(q_resource, db_conn)
+    resource = db_read_query(q_resource, db_conn)
 
     return resource.fhir[0]
 

--- a/tests/test_bundle_limits.py
+++ b/tests/test_bundle_limits.py
@@ -5,7 +5,7 @@ import pandas as pd
 from google.cloud import pubsub_v1
 
 from py_mimic_fhir.bundle import Bundle
-from py_mimic_fhir.db import get_n_patient_id, get_n_resources
+from py_mimic_fhir.db import get_n_patient_id, get_n_resources, db_read_query
 from py_mimic_fhir.lookup import MIMIC_BUNDLE_TABLE_LIST
 from py_mimic_fhir.validate import validate_all_bundles, validate_bundle, revalidate_bundle_from_file
 
@@ -62,7 +62,7 @@ def test_post_100_resources(db_conn, margs, gcp_args):
     q_resource = f"""
         SELECT fhir FROM mimic_fhir.observation_chartevents LIMIT 100000
     """
-    pd_resources = pd.read_sql_query(q_resource, db_conn)
+    pd_resources = db_read_query(q_resource, db_conn)
     resources = pd_resources.fhir.to_list()
     split_flag = True  # Divide up bundles into smaller chunks
 

--- a/tests/test_bundles.py
+++ b/tests/test_bundles.py
@@ -25,7 +25,7 @@ from google.cloud import pubsub_v1
 
 #from fhir.resources.bundle import Bundle
 from py_mimic_fhir.bundle import Bundle
-from py_mimic_fhir.db import get_n_patient_id, get_pat_id_with_links
+from py_mimic_fhir.db import get_n_patient_id, get_pat_id_with_links, db_read_query
 from py_mimic_fhir.lookup import MIMIC_BUNDLE_TABLE_LIST
 from py_mimic_fhir.validate import validate_bundle
 
@@ -35,7 +35,7 @@ def test_bad_bundle(db_conn, margs):
     q_resource = f"""
         SELECT fhir FROM mimic_fhir.patient LIMIT 1
     """
-    pd_resources = pd.read_sql_query(q_resource, db_conn)
+    pd_resources = db_read_query(q_resource, db_conn)
     resource = pd_resources.fhir[0]
     resource['gender'] = 'FAKE CODE'  # Will cause bundle to fail
 
@@ -49,7 +49,7 @@ def test_bad_bundle_gcp(db_conn, margs, gcp_args):
     q_resource = f"""
         SELECT fhir FROM mimic_fhir.patient LIMIT 1
     """
-    pd_resources = pd.read_sql_query(q_resource, db_conn)
+    pd_resources = db_read_query(q_resource, db_conn)
     resource = pd_resources.fhir[0]
     resource['gender'] = 'FAKE CODE'  # Will cause bundle to fail
 
@@ -64,7 +64,7 @@ def test_bad_ref_bundle_gcp(db_conn, margs, gcp_args):
     q_resource = f"""
         SELECT fhir FROM mimic_fhir.encounter LIMIT 1
     """
-    pd_resources = pd.read_sql_query(q_resource, db_conn)
+    pd_resources = db_read_query(q_resource, db_conn)
     resource = pd_resources.fhir[0]
     resource['subject'] = {"reference": "Patient/DOES_NOT_EXISSSSST"}
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,6 +1,7 @@
 import pytest
 import pandas as pd
 import os
+from py_mimic_fhir.db import db_read_query
 
 
 def test_mimic_fhir_row_count(db_conn, dbname):
@@ -15,7 +16,7 @@ def test_mimic_fhir_row_count(db_conn, dbname):
     with open(test_filename) as f:
         sql_statement = f.read()
 
-    results = pd.read_sql_query(sql_statement, db_conn)
+    results = db_read_query(sql_statement, db_conn)
     print(results)
     db_conn.commit()
     assert 'FAIL' not in results['test_status'].values
@@ -33,6 +34,6 @@ def test_mimic_fhir_row_count_approximate(db_conn, dbname):
     with open(test_filename) as f:
         sql_statement = f.read()
 
-    results = pd.read_sql_query(sql_statement, db_conn)
+    results = db_read_query(sql_statement, db_conn)
     print(results)
     assert 'FAIL' not in results['test_status'].values

--- a/tests/test_valueset.py
+++ b/tests/test_valueset.py
@@ -9,6 +9,7 @@ import logging
 import pandas as pd
 import subprocess
 import os
+from py_mimic_fhir.db import db_read_query
 
 MIMIC_TERMINOLOGY_PATH = os.getenv('MIMIC_TERMINOLOGY_PATH')
 JAVA_VALIDATOR = os.getenv('JAVA_VALIDATOR')
@@ -54,7 +55,7 @@ def assert_expanded_and_count(db_conn_hapi, valueset, vs_count):
     q_valueset = f"SELECT expansion_status, total_concepts \
                    FROM trm_valueset WHERE vsname = '{valueset}'"
 
-    result = pd.read_sql_query(q_valueset, db_conn_hapi)
+    result = db_read_query(q_valueset, db_conn_hapi)
     if result.expansion_status[0] == 'EXPANDED' and \
        result.total_concepts[0] == vs_count:
         result = True


### PR DESCRIPTION
This branch integrates some BigQuery features into the mimic-fhir package
- Can now translate the demo database from postgres to BigQuery. Follow [wiki](https://github.com/kind-lab/mimic-fhir/wiki/GCP-load-data-to-BigQuery) tutorial.
- With the demo in BigQuery the option was added to py_mimic_fhir to validate from BigQuery to the healthcare API