### PR TITLE
Updates for MIMIC-IV v2.2 

### DIFF
--- a/sql/codesystem/cs-admission-class.sql
+++ b/sql/codesystem/cs-admission-class.sql
@@ -8,4 +8,4 @@ CREATE TABLE fhir_trm.cs_admission_class(
 
 INSERT INTO fhir_trm.cs_admission_class 
 SELECT DISTINCT admission_type 
-FROM mimic_hosp.admissions 
+FROM mimiciv_hosp.admissions 

--- a/sql/codesystem/cs-admission-type.sql
+++ b/sql/codesystem/cs-admission-type.sql
@@ -8,5 +8,5 @@ CREATE TABLE fhir_trm.cs_admission_type(
 
 INSERT INTO fhir_trm.cs_admission_type
 SELECT DISTINCT admission_type 
-FROM mimic_hosp.admissions 
+FROM mimiciv_hosp.admissions 
 WHERE admission_type != ''

--- a/sql/codesystem/cs-admit-source.sql
+++ b/sql/codesystem/cs-admit-source.sql
@@ -9,7 +9,7 @@ CREATE TABLE fhir_trm.cs_admit_source(
 WITH mimic_admit_source AS (
 
     -- Hospital admission sources
-    SELECT DISTINCT admission_location AS code FROM mimic_hosp.admissions 
+    SELECT DISTINCT admission_location AS code FROM mimiciv_hosp.admissions 
     UNION
     
     -- ED admission sources

--- a/sql/codesystem/cs-admit-source.sql
+++ b/sql/codesystem/cs-admit-source.sql
@@ -13,7 +13,7 @@ WITH mimic_admit_source AS (
     UNION
     
     -- ED admission sources
-    SELECT DISTINCT arrival_transport AS code FROM mimic_ed.edstays 
+    SELECT DISTINCT arrival_transport AS code FROM mimiciv_ed.edstays 
 )
 INSERT INTO fhir_trm.cs_admit_source
 SELECT code

--- a/sql/codesystem/cs-bodysite.sql
+++ b/sql/codesystem/cs-bodysite.sql
@@ -10,5 +10,5 @@ CREATE TABLE fhir_trm.cs_bodysite(
 -- Need to trim and remove white spaces for codes to pass fhir validation
 INSERT INTO fhir_trm.cs_bodysite
 SELECT DISTINCT TRIM(REGEXP_REPLACE(location, '\s+', ' ', 'g'))
-FROM mimic_icu.procedureevents p 
+FROM mimiciv_icu.procedureevents p 
 WHERE location IS NOT NULL

--- a/sql/codesystem/cs-chartevents-d-items.sql
+++ b/sql/codesystem/cs-chartevents-d-items.sql
@@ -13,6 +13,6 @@ SELECT DISTINCT
     itemid AS code
     , label AS display
 FROM 
-    mimic_icu.d_items di 
+    mimiciv_icu.d_items di 
 WHERE linksto = 'chartevents'
             

--- a/sql/codesystem/cs-d-items.sql
+++ b/sql/codesystem/cs-d-items.sql
@@ -12,5 +12,5 @@ INSERT INTO fhir_trm.cs_d_items
 SELECT 
     DISTINCT itemid AS code
     , label AS display
-FROM mimic_icu.d_items di 
+FROM mimiciv_icu.d_items di 
 WHERE linksto IN ('procedureevents', 'datetimeevents', 'outputevents');

--- a/sql/codesystem/cs-d-labitems.sql
+++ b/sql/codesystem/cs-d-labitems.sql
@@ -12,4 +12,4 @@ INSERT INTO fhir_trm.cs_d_labitems
 SELECT 
     itemid AS code
     , label AS display
-FROM mimic_hosp.d_labitems 
+FROM mimiciv_hosp.d_labitems 

--- a/sql/codesystem/cs-descriptions.sql
+++ b/sql/codesystem/cs-descriptions.sql
@@ -29,7 +29,7 @@ VALUES
     , ('medication_formulary_drug_cd', 'Medication formulary drug codes for use in prescriptions and emar')
     , ('medication_frequency', 'The medication frequency reported for medication delivery in MIMIC')
     , ('medication_gsn', 'The medication GSN codes for MIMIC')
-    , ('medication_icu', 'All medication found in the ICU, derived from mimic_icu.d_items')   
+    , ('medication_icu', 'All medication found in the ICU, derived from mimiciv_icu.d_items')   
     , ('medication_method', 'The medication delivery method for MIMIC')
     , ('medication_method_icu', 'The medication delivery method used in the ICU for MIMIC')
     , ('medication_name', 'The standard medication name used in MIMIC. Used in pharmacy, prescriptions, and emar')

--- a/sql/codesystem/cs-diagnosis-icd10.sql
+++ b/sql/codesystem/cs-diagnosis-icd10.sql
@@ -1,5 +1,5 @@
 -- Generate codes for diagnosis-icd10 codesystem
--- Take codes used in mimic_hosp.diagnosis_icd and mimic_ed.diagnosis
+-- Take codes used in mimiciv_hosp.diagnosis_icd and mimic_ed.diagnosis
 -- Combine all the codes from MIMIC-IV and MIMIC-ED to make sure all ICD codes captured
 -- Need to trim to remove whitespaces, or validator will fail it
 -- FUTURE: fhir should have all these codes in the terminology server, but only have fragmented version.
@@ -18,8 +18,8 @@ WITH icd10_codes AS (
         DISTINCT TRIM(diag.icd_code) AS code
         , icd.long_title AS display
     FROM 
-        mimic_hosp.diagnoses_icd diag
-        LEFT JOIN mimic_hosp.d_icd_diagnoses icd
+        mimiciv_hosp.diagnoses_icd diag
+        LEFT JOIN mimiciv_hosp.d_icd_diagnoses icd
             ON diag.icd_code = icd.icd_code 
             AND diag.icd_version = icd.icd_version 
     WHERE diag.icd_version = 10

--- a/sql/codesystem/cs-diagnosis-icd10.sql
+++ b/sql/codesystem/cs-diagnosis-icd10.sql
@@ -1,5 +1,5 @@
 -- Generate codes for diagnosis-icd10 codesystem
--- Take codes used in mimiciv_hosp.diagnosis_icd and mimic_ed.diagnosis
+-- Take codes used in mimiciv_hosp.diagnosis_icd and mimiciv_ed.diagnosis
 -- Combine all the codes from MIMIC-IV and MIMIC-ED to make sure all ICD codes captured
 -- Need to trim to remove whitespaces, or validator will fail it
 -- FUTURE: fhir should have all these codes in the terminology server, but only have fragmented version.
@@ -30,7 +30,7 @@ WITH icd10_codes AS (
         DISTINCT TRIM(eddg.icd_code) AS code
         , eddg.icd_title AS display
     FROM
-        mimic_ed.diagnosis eddg
+        mimiciv_ed.diagnosis eddg
     WHERE icd_version = 10   
 )
 INSERT INTO fhir_trm.cs_diagnosis_icd10

--- a/sql/codesystem/cs-diagnosis-icd9.sql
+++ b/sql/codesystem/cs-diagnosis-icd9.sql
@@ -29,7 +29,7 @@ WITH icd9_codes AS (
         DISTINCT TRIM(eddg.icd_code) AS code
         , eddg.icd_title AS display
     FROM
-        mimic_ed.diagnosis eddg
+        mimiciv_ed.diagnosis eddg
     WHERE icd_version = 9   
 )
 INSERT INTO fhir_trm.cs_diagnosis_icd9

--- a/sql/codesystem/cs-diagnosis-icd9.sql
+++ b/sql/codesystem/cs-diagnosis-icd9.sql
@@ -17,8 +17,8 @@ WITH icd9_codes AS (
         DISTINCT TRIM(diag.icd_code) AS code
         , icd.long_title AS display
     FROM 
-        mimic_hosp.diagnoses_icd diag
-        LEFT JOIN mimic_hosp.d_icd_diagnoses icd
+        mimiciv_hosp.diagnoses_icd diag
+        LEFT JOIN mimiciv_hosp.d_icd_diagnoses icd
             ON diag.icd_code = icd.icd_code 
             AND diag.icd_version = icd.icd_version 
     WHERE diag.icd_version = 9

--- a/sql/codesystem/cs-discharge-disposition.sql
+++ b/sql/codesystem/cs-discharge-disposition.sql
@@ -9,7 +9,7 @@ CREATE TABLE fhir_trm.cs_discharge_disposition(
 WITH mimic_discharge_disposition AS (
 
     -- Hospital admission sources
-    SELECT DISTINCT discharge_location AS code FROM mimic_hosp.admissions 
+    SELECT DISTINCT discharge_location AS code FROM mimiciv_hosp.admissions 
     UNION
     
     -- ED admission sources

--- a/sql/codesystem/cs-discharge-disposition.sql
+++ b/sql/codesystem/cs-discharge-disposition.sql
@@ -13,7 +13,7 @@ WITH mimic_discharge_disposition AS (
     UNION
     
     -- ED admission sources
-    SELECT DISTINCT disposition AS code FROM mimic_ed.edstays 
+    SELECT DISTINCT disposition AS code FROM mimiciv_ed.edstays 
 )
 INSERT INTO fhir_trm.cs_discharge_disposition
 SELECT code

--- a/sql/codesystem/cs-hcpcs-cd.sql
+++ b/sql/codesystem/cs-hcpcs-cd.sql
@@ -12,5 +12,5 @@ INSERT INTO fhir_trm.cs_hcpcs_cd
 SELECT DISTINCT  
     hcpcs_cd AS code
     , short_description AS display
-FROM mimic_hosp.hcpcsevents  
+FROM mimiciv_hosp.hcpcsevents  
 WHERE hcpcs_cd IS NOT NULL;

--- a/sql/codesystem/cs-lab-flags.sql
+++ b/sql/codesystem/cs-lab-flags.sql
@@ -8,5 +8,5 @@ CREATE TABLE fhir_trm.cs_lab_flags(
 
 INSERT INTO fhir_trm.cs_lab_flags
 SELECT DISTINCT flag AS code
-FROM mimic_hosp.labevents  
+FROM mimiciv_hosp.labevents  
 WHERE flag IS NOT NULL 

--- a/sql/codesystem/cs-lab-fluid.sql
+++ b/sql/codesystem/cs-lab-fluid.sql
@@ -8,4 +8,4 @@ CREATE TABLE fhir_trm.cs_lab_fluid(
 
 INSERT INTO fhir_trm.cs_lab_fluid
 SELECT DISTINCT fluid
-FROM mimic_hosp.d_labitems;
+FROM mimiciv_hosp.d_labitems;

--- a/sql/codesystem/cs-lab-priority.sql
+++ b/sql/codesystem/cs-lab-priority.sql
@@ -8,5 +8,5 @@ CREATE TABLE fhir_trm.cs_lab_priority(
 
 INSERT INTO fhir_trm.cs_lab_priority 
 SELECT DISTINCT priority 
-FROM mimic_hosp.labevents
+FROM mimiciv_hosp.labevents
 WHERE priority IS NOT NULL; 

--- a/sql/codesystem/cs-medadmin-category-icu.sql
+++ b/sql/codesystem/cs-medadmin-category-icu.sql
@@ -8,4 +8,4 @@ CREATE TABLE fhir_trm.cs_medadmin_category_icu(
 
 INSERT INTO fhir_trm.cs_medadmin_category_icu
 SELECT DISTINCT ordercategoryname 
-FROM mimic_icu.inputevents 
+FROM mimiciv_icu.inputevents 

--- a/sql/codesystem/cs-medication-etc.sql
+++ b/sql/codesystem/cs-medication-etc.sql
@@ -1,6 +1,6 @@
 -- Medication ETC CodeSystem (for MIMIC-ED)
 -- Enhanced Therapeutic Class codes will need to be mapped in future to a standard medication system (ie using rxnorm)
--- ETC codes pulled in from mimic_ed.medrecon mimic_ed.pyxis
+-- ETC codes pulled in from mimiciv_ed.medrecon mimiciv_ed.pyxis
 
 DROP TABLE IF EXISTS fhir_trm.cs_medication_etc;
 CREATE TABLE fhir_trm.cs_medication_etc(
@@ -12,7 +12,7 @@ INSERT INTO fhir_trm.cs_medication_etc
 SELECT
     etccode AS code
     , MAX(etcdescription) AS display -- grab one description
-FROM mimic_ed.medrecon 
+FROM mimiciv_ed.medrecon 
 WHERE 
     etccode IS NOT NULL 
 GROUP BY etccode

--- a/sql/codesystem/cs-medication-formulary-drug-cd.sql
+++ b/sql/codesystem/cs-medication-formulary-drug-cd.sql
@@ -7,9 +7,9 @@ CREATE TABLE fhir_trm.cs_medication_formulary_drug_cd(
 );
 
 WITH formulary_drug_cd AS (
-    SELECT DISTINCT formulary_drug_cd AS code FROM mimic_hosp.prescriptions p     
+    SELECT DISTINCT formulary_drug_cd AS code FROM mimiciv_hosp.prescriptions p     
     UNION    
-    SELECT DISTINCT product_code AS  code FROM mimic_hosp.emar_detail ed 
+    SELECT DISTINCT product_code AS  code FROM mimiciv_hosp.emar_detail ed 
 )
 INSERT INTO fhir_trm.cs_medication_formulary_drug_cd 
 SELECT code

--- a/sql/codesystem/cs-medication-frequency.sql
+++ b/sql/codesystem/cs-medication-frequency.sql
@@ -8,5 +8,5 @@ CREATE TABLE fhir_trm.cs_medication_frequency(
 
 INSERT INTO fhir_trm.cs_medication_frequency
 SELECT DISTINCT TRIM(REGEXP_REPLACE(frequency, '\s+', ' ', 'g')) AS code 
-FROM mimic_hosp.pharmacy p 
+FROM mimiciv_hosp.pharmacy p 
 WHERE frequency IS NOT NULL;

--- a/sql/codesystem/cs-medication-gsn.sql
+++ b/sql/codesystem/cs-medication-gsn.sql
@@ -1,6 +1,6 @@
 -- Medication GSN CodeSystem (for MIMIC-ED)
 -- Generic Sequence Number Codes will need to be mapped in future to a standard medication system (ie using rxnorm)
--- GSN codes pulled in from mimic_ed.medrecon mimic_ed.pyxis
+-- GSN codes pulled in from mimiciv_ed.medrecon mimiciv_ed.pyxis
 
 DROP TABLE IF EXISTS fhir_trm.cs_medication_gsn;
 CREATE TABLE fhir_trm.cs_medication_gsn(
@@ -8,9 +8,9 @@ CREATE TABLE fhir_trm.cs_medication_gsn(
 );
 
 WITH mimic_gsn AS (
-    SELECT DISTINCT gsn FROM mimic_ed.medrecon
+    SELECT DISTINCT gsn FROM mimiciv_ed.medrecon
     UNION
-    SELECT DISTINCT gsn FROM mimic_ed.pyxis
+    SELECT DISTINCT gsn FROM mimiciv_ed.pyxis
 )
 INSERT INTO fhir_trm.cs_medication_gsn
 SELECT gsn AS code

--- a/sql/codesystem/cs-medication-icu.sql
+++ b/sql/codesystem/cs-medication-icu.sql
@@ -11,6 +11,6 @@ INSERT INTO fhir_trm.cs_medication_icu
 SELECT 
     itemid AS code
     , LABEL AS display
-FROM mimic_icu.d_items 
+FROM mimiciv_icu.d_items 
 WHERE linksto='inputevents'
 

--- a/sql/codesystem/cs-medication-method-icu.sql
+++ b/sql/codesystem/cs-medication-method-icu.sql
@@ -8,4 +8,4 @@ CREATE TABLE fhir_trm.cs_medication_method_icu(
 
 INSERT INTO fhir_trm.cs_medication_method_icu
 SELECT DISTINCT TRIM(ordercategorydescription)
-FROM mimic_icu.inputevents; 
+FROM mimiciv_icu.inputevents; 

--- a/sql/codesystem/cs-medication-method.sql
+++ b/sql/codesystem/cs-medication-method.sql
@@ -8,6 +8,6 @@ CREATE TABLE fhir_trm.cs_medication_method(
 
 INSERT INTO fhir_trm.cs_medication_method
 SELECT DISTINCT TRIM(event_txt) 
-FROM mimic_hosp.emar  
+FROM mimiciv_hosp.emar  
 WHERE event_txt IS NOT NULL;
 

--- a/sql/codesystem/cs-medication-name.sql
+++ b/sql/codesystem/cs-medication-name.sql
@@ -9,21 +9,21 @@ CREATE TABLE fhir_trm.cs_medication_name(
 WITH medication_name AS (
     -- prescription names are fully captured in pharmacy currently, but keeping incase this changes in future
     SELECT DISTINCT TRIM(REGEXP_REPLACE(drug, '\s+', ' ', 'g')) AS code 
-    FROM mimic_hosp.prescriptions 
+    FROM mimiciv_hosp.prescriptions 
     WHERE formulary_drug_cd IS NULL
     
     UNION    
     
     SELECT DISTINCT TRIM(REGEXP_REPLACE(medication, '\s+', ' ', 'g')) AS  code 
-    FROM mimic_hosp.pharmacy
+    FROM mimiciv_hosp.pharmacy
     
     UNION 
     
     SELECT 
         DISTINCT TRIM(REGEXP_REPLACE(medication, '\s+', ' ', 'g')) AS code
     FROM 
-        mimic_hosp.emar_detail emd 
-        LEFT JOIN mimic_hosp.emar em
+        mimiciv_hosp.emar_detail emd 
+        LEFT JOIN mimiciv_hosp.emar em
             ON emd.emar_id = em.emar_id
 )
 

--- a/sql/codesystem/cs-medication-ndc.sql
+++ b/sql/codesystem/cs-medication-ndc.sql
@@ -8,7 +8,7 @@ CREATE TABLE fhir_trm.cs_medication_ndc(
 
 INSERT INTO fhir_trm.cs_medication_ndc 
 SELECT DISTINCT ndc AS code
-FROM mimic_hosp.prescriptions 
+FROM mimiciv_hosp.prescriptions 
 WHERE 
     ndc IS NOT NULL
     AND ndc != '';

--- a/sql/codesystem/cs-medication-poe-iv.sql
+++ b/sql/codesystem/cs-medication-poe-iv.sql
@@ -9,5 +9,5 @@ CREATE TABLE fhir_trm.cs_medication_poe_iv(
 INSERT INTO fhir_trm.cs_medication_poe_iv
 SELECT 
     DISTINCT order_type
-FROM mimic_hosp.poe
+FROM mimiciv_hosp.poe
 WHERE order_type IN ('TPN', 'IV therapy')

--- a/sql/codesystem/cs-medication-route.sql
+++ b/sql/codesystem/cs-medication-route.sql
@@ -9,9 +9,9 @@ CREATE TABLE fhir_trm.cs_medication_route(
 
 
 WITH med_routes AS (
-    SELECT DISTINCT TRIM(route) AS route FROM mimic_hosp.emar_detail 
+    SELECT DISTINCT TRIM(route) AS route FROM mimiciv_hosp.emar_detail 
     UNION
-    SELECT DISTINCT TRIM(route) AS route FROM mimic_hosp.pharmacy
+    SELECT DISTINCT TRIM(route) AS route FROM mimiciv_hosp.pharmacy
 ) 
 INSERT INTO fhir_trm.cs_medication_route
 SELECT route

--- a/sql/codesystem/cs-medication-site.sql
+++ b/sql/codesystem/cs-medication-site.sql
@@ -8,7 +8,7 @@ CREATE TABLE fhir_trm.cs_medication_site(
 
 INSERT INTO fhir_trm.cs_medication_site
 SELECT DISTINCT TRIM(REGEXP_REPLACE(site, '\s+', ' ', 'g')) -- need TO remove ALL whitespaces TO pass fhir validation
-FROM mimic_hosp.emar_detail
+FROM mimiciv_hosp.emar_detail
 WHERE 
     site IS NOT NULL 
     AND TRIM(REGEXP_REPLACE(site, '\s+', ' ', 'g')) != ''

--- a/sql/codesystem/cs-microbiology-antibiotic.sql
+++ b/sql/codesystem/cs-microbiology-antibiotic.sql
@@ -10,5 +10,5 @@ INSERT INTO fhir_trm.cs_microbiology_antibiotic
 SELECT DISTINCT 
     ab_itemid AS code
     , ab_name AS display
-FROM mimic_hosp.microbiologyevents m 
+FROM mimiciv_hosp.microbiologyevents m 
 WHERE ab_itemid IS NOT NULL

--- a/sql/codesystem/cs-microbiology-interpretation.sql
+++ b/sql/codesystem/cs-microbiology-interpretation.sql
@@ -7,5 +7,5 @@ CREATE TABLE fhir_trm.cs_microbiology_interpretation(
 
 INSERT INTO fhir_trm.cs_microbiology_interpretation
 SELECT DISTINCT interpretation 
-FROM mimic_hosp.microbiologyevents m 
+FROM mimiciv_hosp.microbiologyevents m 
 WHERE interpretation IS NOT NULL

--- a/sql/codesystem/cs-microbiology-organism.sql
+++ b/sql/codesystem/cs-microbiology-organism.sql
@@ -9,5 +9,5 @@ CREATE TABLE fhir_trm.cs_microbiology_organism(
 
 INSERT INTO fhir_trm.cs_microbiology_organism
 SELECT DISTINCT org_itemid, org_name 
-FROM mimic_hosp.microbiologyevents m 
+FROM mimiciv_hosp.microbiologyevents m 
 WHERE org_itemid IS NOT NULL

--- a/sql/codesystem/cs-microbiology-test.sql
+++ b/sql/codesystem/cs-microbiology-test.sql
@@ -10,5 +10,5 @@ INSERT INTO fhir_trm.cs_microbiology_test
 SELECT DISTINCT 
     test_itemid AS code
     , test_name AS display 
-FROM mimic_hosp.microbiologyevents m 
+FROM mimiciv_hosp.microbiologyevents m 
 WHERE test_itemid IS NOT NULL

--- a/sql/codesystem/cs-observation-category.sql
+++ b/sql/codesystem/cs-observation-category.sql
@@ -8,6 +8,6 @@ CREATE TABLE fhir_trm.cs_observation_category(
 
 INSERT INTO fhir_trm.cs_observation_category
 SELECT DISTINCT di.category
-FROM mimic_icu.d_items di 
+FROM mimiciv_icu.d_items di 
 
 

--- a/sql/codesystem/cs-procedure-category.sql
+++ b/sql/codesystem/cs-procedure-category.sql
@@ -9,4 +9,4 @@ CREATE TABLE fhir_trm.cs_procedure_category(
 
 INSERT INTO fhir_trm.cs_procedure_category
 SELECT DISTINCT ordercategoryname 
-FROM mimic_icu.procedureevents p 
+FROM mimiciv_icu.procedureevents p 

--- a/sql/codesystem/cs-procedure-icd10.sql
+++ b/sql/codesystem/cs-procedure-icd10.sql
@@ -14,8 +14,8 @@ SELECT DISTINCT
     TRIM(proc.icd_code) AS code
     , icd.long_title AS display
 FROM 
-    mimic_hosp.procedures_icd proc
-    LEFT JOIN mimic_hosp.d_icd_procedures icd
+    mimiciv_hosp.procedures_icd proc
+    LEFT JOIN mimiciv_hosp.d_icd_procedures icd
         ON proc.icd_code = icd.icd_code 
         AND proc.icd_version = icd.icd_version 
 WHERE proc.icd_version = 10

--- a/sql/codesystem/cs-procedure-icd9.sql
+++ b/sql/codesystem/cs-procedure-icd9.sql
@@ -13,8 +13,8 @@ SELECT DISTINCT
     TRIM(proc.icd_code) AS code
     , icd.long_title AS display
 FROM 
-    mimic_hosp.procedures_icd proc
-    LEFT JOIN mimic_hosp.d_icd_procedures icd
+    mimiciv_hosp.procedures_icd proc
+    LEFT JOIN mimiciv_hosp.d_icd_procedures icd
         ON proc.icd_code = icd.icd_code 
         AND proc.icd_version = icd.icd_version 
 WHERE proc.icd_version = 9

--- a/sql/codesystem/cs-services.sql
+++ b/sql/codesystem/cs-services.sql
@@ -8,4 +8,4 @@ CREATE TABLE fhir_trm.cs_services(
 
 INSERT INTO fhir_trm.cs_services 
 SELECT DISTINCT curr_service
-FROM mimic_hosp.services;
+FROM mimiciv_hosp.services;

--- a/sql/codesystem/cs-spec-type-desc.sql
+++ b/sql/codesystem/cs-spec-type-desc.sql
@@ -11,5 +11,5 @@ INSERT INTO fhir_trm.cs_spec_type_desc
 SELECT DISTINCT 
     spec_itemid AS code
     , spec_type_desc AS display
-FROM mimic_hosp.microbiologyevents
+FROM mimiciv_hosp.microbiologyevents
 WHERE spec_type_desc != '';

--- a/sql/codesystem/cs-units.sql
+++ b/sql/codesystem/cs-units.sql
@@ -8,31 +8,31 @@ CREATE TABLE fhir_trm.cs_units(
 
 
 WITH mimic_units AS (
-    SELECT DISTINCT TRIM(REGEXP_REPLACE(dose_due_unit, '\s+', ' ', 'g')) AS unit FROM mimic_hosp.emar_detail
+    SELECT DISTINCT TRIM(REGEXP_REPLACE(dose_due_unit, '\s+', ' ', 'g')) AS unit FROM mimiciv_hosp.emar_detail
     UNION
-    SELECT DISTINCT TRIM(infusion_rate_unit) AS unit FROM mimic_hosp.emar_detail
+    SELECT DISTINCT TRIM(infusion_rate_unit) AS unit FROM mimiciv_hosp.emar_detail
     UNION 
     
     -- Medication Administration ICU units
-    SELECT DISTINCT TRIM(amountuom)  AS unit FROM mimic_icu.inputevents 
+    SELECT DISTINCT TRIM(amountuom)  AS unit FROM mimiciv_icu.inputevents 
     UNION
-    SELECT DISTINCT TRIM(rateuom) AS unit FROM mimic_icu.inputevents 
+    SELECT DISTINCT TRIM(rateuom) AS unit FROM mimiciv_icu.inputevents 
     UNION 
     
     -- Chartevents units 
-    SELECT DISTINCT TRIM(valueuom) AS unit FROM mimic_icu.chartevents  
+    SELECT DISTINCT TRIM(valueuom) AS unit FROM mimiciv_icu.chartevents  
     UNION
     
     -- Observation labs units
-    SELECT DISTINCT TRIM(valueuom) AS unit FROM mimic_hosp.labevents   
+    SELECT DISTINCT TRIM(valueuom) AS unit FROM mimiciv_hosp.labevents   
     UNION
     
     -- Outputevents units 
-    SELECT DISTINCT TRIM(valueuom) AS unit FROM mimic_icu.outputevents  
+    SELECT DISTINCT TRIM(valueuom) AS unit FROM mimiciv_icu.outputevents  
     UNION
     
     -- Prescription units 
-    SELECT DISTINCT TRIM(dose_unit_rx) AS unit FROM mimic_hosp.prescriptions p   
+    SELECT DISTINCT TRIM(dose_unit_rx) AS unit FROM mimiciv_hosp.prescriptions p   
 )
 INSERT INTO fhir_trm.cs_units
 SELECT unit

--- a/sql/codesystem/vs-datetimeevents-d-items.sql
+++ b/sql/codesystem/vs-datetimeevents-d-items.sql
@@ -14,6 +14,6 @@ SELECT DISTINCT
     'http://mimic.mit.edu/fhir/mimic/CodeSystem/mimic-d-items'
     , itemid AS code
     , LABEL AS display
-FROM mimic_icu.d_items di 
+FROM mimiciv_icu.d_items di 
 WHERE linksto = 'datetimeevents'
             

--- a/sql/codesystem/vs-outputevents-d-items.sql
+++ b/sql/codesystem/vs-outputevents-d-items.sql
@@ -14,5 +14,5 @@ SELECT DISTINCT
     'http://mimic.mit.edu/fhir/mimic/CodeSystem/mimic-d-items' AS system
     , itemid AS code
     , label AS display
-FROM mimic_icu.d_items 
+FROM mimiciv_icu.d_items 
 WHERE linksto = 'outputevents'

--- a/sql/codesystem/vs-procedureevents-d-items.sql
+++ b/sql/codesystem/vs-procedureevents-d-items.sql
@@ -14,6 +14,6 @@ SELECT DISTINCT
     'http://mimic.mit.edu/fhir/mimic/CodeSystem/mimic-d-items' AS system
     , itemid AS code
     , label AS display
-FROM mimic_icu.d_items 
+FROM mimiciv_icu.d_items 
 WHERE linksto = 'procedureevents'
             

--- a/sql/create_fhir_jsons.sql
+++ b/sql/create_fhir_jsons.sql
@@ -1,5 +1,7 @@
-\set outputdir '/tmp/mimic_output'
-\! mkdir -p '/tmp/mimic_output'
+--\set outputdir '/tmp/mimic_output'
+--\! mkdir -p '/tmp/mimic_output'
+\set outputdir '/Volumes/Samsung SSD T7/mimic-fhir-demo'
+
 \t
 -- removes single space in front of output
 \pset format unaligned 
@@ -8,113 +10,140 @@
 
 -- institutional resources
 \echo organization
-\o :outputdir/MimicOrganization.ndjson
-SELECT fhir FROM mimic_fhir.organization;
+\set outputfile :outputdir/MimicOrganization.ndjson
+\set command '\\copy (SELECT fhir FROM mimic_fhir.organization) TO ' :'outputfile' 
+:command
 
 \echo location
-\o :outputdir/MimicLocation.ndjson
-SELECT fhir FROM mimic_fhir.location;
+\set outputfile :outputdir/MimicLocation.ndjson
+\set command '\\copy (SELECT fhir FROM mimic_fhir.location) TO ' :'outputfile' 
+:command
 
 -- patient tracking resources
 \echo patient
-\o :outputdir/MimicPatient.ndjson
-SELECT fhir FROM mimic_fhir.patient;
+\set outputfile :outputdir/MimicPatient.ndjson
+\set command '\\copy (SELECT fhir FROM mimic_fhir.patient) TO ' :'outputfile' 
+:command
 
 \echo encounter
-\o :outputdir/MimicEncounter.ndjson
-SELECT fhir FROM mimic_fhir.encounter;
+\set outputfile :outputdir/MimicEncounter.ndjson
+\set command '\\copy (SELECT fhir FROM mimic_fhir.encounter) TO ' :'outputfile' 
+:command
 
 \echo encounter
-\o :outputdir/MimicEncounterED.ndjson
-SELECT fhir FROM mimic_fhir.encounter_ed;
+\set outputfile :outputdir/MimicEncounterED.ndjson
+\set command '\\copy (SELECT fhir FROM mimic_fhir.encounter_ed) TO ' :'outputfile' 
+:command
 
 \echo encounter_icu
-\o :outputdir/MimicEncounterICU.ndjson
-SELECT fhir FROM mimic_fhir.encounter_icu;
+\set outputfile :outputdir/MimicEncounterICU.ndjson
+\set command '\\copy (SELECT fhir FROM mimic_fhir.encounter_icu) TO ' :'outputfile' 
+:command
 
 -- data resources: conditions, diagnoses, procedures
 \echo condition
-\o :outputdir/MimicCondition.ndjson
-SELECT fhir FROM mimic_fhir.condition;
+\set outputfile :outputdir/MimicCondition.ndjson
+\set command '\\copy (SELECT fhir FROM mimic_fhir.condition) TO ' :'outputfile' 
+:command
 
 \echo condition ED
-\o :outputdir/MimicConditionED.ndjson
-SELECT fhir FROM mimic_fhir.condition_ed;
+\set outputfile :outputdir/MimicConditionED.ndjson
+\set command '\\copy (SELECT fhir FROM mimic_fhir.condition_ed) TO ' :'outputfile' 
+:command
 
 \echo procedure
-\o :outputdir/MimicProcedure.ndjson
-SELECT fhir FROM mimic_fhir.procedure;
+\set outputfile :outputdir/MimicProcedure.ndjson
+\set command '\\copy (SELECT fhir FROM mimic_fhir.procedure) TO ' :'outputfile' 
+:command
 
 \echo procedure ED
-\o :outputdir/MimicProcedureED.ndjson
-SELECT fhir FROM mimic_fhir.procedure_ed;
+\set outputfile :outputdir/MimicProcedureED.ndjson
+\set command '\\copy (SELECT fhir FROM mimic_fhir.procedure_ed) TO ' :'outputfile' 
+:command
 
 \echo procedure_icu
-\o :outputdir/MimicProcedureICU.ndjson
-SELECT fhir FROM mimic_fhir.procedure_icu;
+\set outputfile :outputdir/MimicProcedureICU.ndjson
+\set command '\\copy (SELECT fhir FROM mimic_fhir.procedure_icu) TO ' :'outputfile' 
+:command
 
 -- data resources: medications
 \echo medication
-\o :outputdir/MimicMedication.ndjson
-SELECT fhir FROM mimic_fhir.medication;
+\set outputfile :outputdir/MimicMedication.ndjson
+\set command '\\copy (SELECT fhir FROM mimic_fhir.medication) TO ' :'outputfile' 
+:command
 
 \echo medication_request
-\o :outputdir/MimicMedicationRequest.ndjson
-SELECT fhir FROM mimic_fhir.medication_request;
+\set outputfile :outputdir/MimicMedicationRequest.ndjson
+\set command '\\copy (SELECT fhir FROM mimic_fhir.medication_request) TO ' :'outputfile' 
+:command
 
 \echo medication_dispense
-\o :outputdir/MimicMedicationDispense.ndjson
-SELECT fhir FROM mimic_fhir.medication_dispense;
+\set outputfile :outputdir/MimicMedicationDispense.ndjson
+\set command '\\copy (SELECT fhir FROM mimic_fhir.medication_dispense) TO ' :'outputfile' 
+:command
 
 \echo medication_dispense_ed
-\o :outputdir/MimicMedicationDispenseED.ndjson
-SELECT fhir FROM mimic_fhir.medication_dispense_ed;
+\set outputfile :outputdir/MimicMedicationDispenseED.ndjson
+\set command '\\copy (SELECT fhir FROM mimic_fhir.medication_dispense_ed) TO ' :'outputfile' 
+:command
 
 \echo medadmin
-\o :outputdir/MimicMedicationAdministration.ndjson
-SELECT fhir FROM mimic_fhir.medication_administration;
+\set outputfile :outputdir/MimicMedicationAdministration.ndjson
+\set command '\\copy (SELECT fhir FROM mimic_fhir.medication_administration) TO ' :'outputfile' 
+:command
 
 \echo medication_administration_icu
-\o :outputdir/MimicMedicationAdministrationICU.ndjson
-SELECT fhir FROM mimic_fhir.medication_administration_icu;
+\set outputfile :outputdir/MimicMedicationAdministrationICU.ndjson
+\set command '\\copy (SELECT fhir FROM mimic_fhir.medication_administration_icu) TO ' :'outputfile' 
+:command
 
 \echo medication_statement_ed
-\o :outputdir/MimicMedicationStatementED.ndjson
-SELECT fhir FROM mimic_fhir.medication_statement_ed;
+\set outputfile :outputdir/MimicMedicationStatementED.ndjson
+\set command '\\copy (SELECT fhir FROM mimic_fhir.medication_statement_ed) TO ' :'outputfile' 
+:command
 
 -- diagnostic resources
 \echo observation_labevents
-\o :outputdir/MimicObservationLabevents.ndjson
-SELECT fhir FROM mimic_fhir.observation_labevents;
+\set outputfile :outputdir/MimicObservationLabevents.ndjson
+\set command '\\copy (SELECT fhir FROM mimic_fhir.observation_labevents) TO ' :'outputfile' 
+:command
 
 \echo observation_micro_org
-\o :outputdir/MimicObservationMicroOrg.ndjson
-SELECT fhir FROM mimic_fhir.observation_micro_org;
+\set outputfile :outputdir/MimicObservationMicroOrg.ndjson
+\set command '\\copy (SELECT fhir FROM mimic_fhir.observation_micro_org) TO ' :'outputfile' 
+:command
 
 \echo observation_micro_susc
-\o :outputdir/MimicObservationMicroSusc.ndjson
-SELECT fhir FROM mimic_fhir.observation_micro_susc;
+\set outputfile :outputdir/MimicObservationMicroSusc.ndjson
+\set command '\\copy (SELECT fhir FROM mimic_fhir.observation_micro_susc) TO ' :'outputfile' 
+:command
 
 \echo observation_micro_test
-\o :outputdir/MimicObservationMicroTest.ndjson
-SELECT fhir FROM mimic_fhir.observation_micro_test;
+\set outputfile :outputdir/MimicObservationMicroTest.ndjson
+\set command '\\copy (SELECT fhir FROM mimic_fhir.observation_micro_test) TO ' :'outputfile' 
+:command
 
 \echo observation_chartevents
-\o :outputdir/MimicObservationChartevents.ndjson
-SELECT fhir FROM mimic_fhir.observation_chartevents;
+\set outputfile :outputdir/MimicObservationChartevents.ndjson
+\set command '\\copy (SELECT fhir FROM mimic_fhir.observation_chartevents) TO ' :'outputfile' 
+:command
 
 \echo observation_datetimeevents
-\o :outputdir/MimicObservationDatetimeevents.ndjson
-SELECT fhir FROM mimic_fhir.observation_datetimeevents;
+\set outputfile :outputdir/MimicObservationDatetimeevents.ndjson
+\set command '\\copy (SELECT fhir FROM mimic_fhir.observation_datetimeevents) TO ' :'outputfile' 
+:command
 
 \echo observation_outputevents
-\o :outputdir/MimicObservationOutputevents.ndjson
-SELECT fhir FROM mimic_fhir.observation_outputevents;
+\set outputfile :outputdir/MimicObservationOutputevents.ndjson
+\set command '\\copy (SELECT fhir FROM mimic_fhir.observation_outputevents) TO ' :'outputfile' 
+:command
 
 \echo observation_ed
-\o :outputdir/MimicObservationED.ndjson
-SELECT fhir FROM mimic_fhir.observation_ed;
+\set outputfile :outputdir/MimicObservationED.ndjson
+\set command '\\copy (SELECT fhir FROM mimic_fhir.observation_ed) TO ' :'outputfile' 
+:command
 
 \echo observation_vitalsigns
-\o :outputdir/MimicObservationVitalSigns.ndjson
-SELECT fhir FROM mimic_fhir.observation_vital_signs;
+\set outputfile :outputdir/MimicObservationVitalSigns.ndjson
+\set command '\\copy (SELECT fhir FROM mimic_fhir.observation_vital_signs) TO ' :'outputfile' 
+:command

--- a/sql/create_mimic_index.sql
+++ b/sql/create_mimic_index.sql
@@ -1,33 +1,33 @@
 DROP INDEX IF EXISTS labevents_idx02;
 CREATE INDEX labevents_idx02
-  ON mimic_hosp.labevents (specimen_id);
+  ON mimiciv_hosp.labevents (specimen_id);
   
 DROP INDEX IF EXISTS labevents_idx03;
 CREATE INDEX labevents_idx03
-  ON mimic_hosp.labevents (itemid);
+  ON mimiciv_hosp.labevents (itemid);
   
 DROP INDEX IF EXISTS d_labitems_idx01;
 CREATE INDEX d_labitems_idx01
-  ON mimic_hosp.d_labitems (itemid);
+  ON mimiciv_hosp.d_labitems (itemid);
   
 DROP INDEX IF EXISTS pharmacy_idx01;
 CREATE INDEX pharmacy_idx01
-  ON mimic_hosp.pharmacy (pharmacy_id);
+  ON mimiciv_hosp.pharmacy (pharmacy_id);
   
   
 DROP INDEX IF EXISTS prescriptions_idx01;
 CREATE INDEX prescriptions_idx01
-  ON mimic_hosp.prescriptions (pharmacy_id);
+  ON mimiciv_hosp.prescriptions (pharmacy_id);
   
   
 DROP INDEX IF EXISTS emar_idx01;
 CREATE INDEX emar_idx01
-  ON mimic_hosp.emar (pharmacy_id);
+  ON mimiciv_hosp.emar (pharmacy_id);
   
 DROP INDEX IF EXISTS emar_idx02;
 CREATE INDEX emar_idx02
-  ON mimic_hosp.emar (poe_id);
+  ON mimiciv_hosp.emar (poe_id);
   
 DROP INDEX IF EXISTS poe_idx01;
 CREATE INDEX poe_idx01
-  ON mimic_hosp.poe (poe_id);
+  ON mimiciv_hosp.poe (poe_id);

--- a/sql/fhir_condition.sql
+++ b/sql/fhir_condition.sql
@@ -19,8 +19,8 @@ WITH fhir_condition AS (
         , uuid_generate_v5(ns_patient.uuid, CAST(diag.subject_id AS TEXT)) as uuid_SUBJECT_ID
         , uuid_generate_v5(ns_encounter.uuid, CAST(diag.hadm_id AS TEXT)) as uuid_HADM_ID
     FROM
-        mimic_hosp.diagnoses_icd diag
-        LEFT JOIN mimic_hosp.d_icd_diagnoses icd
+        mimiciv_hosp.diagnoses_icd diag
+        LEFT JOIN mimiciv_hosp.d_icd_diagnoses icd
             ON diag.icd_code = icd.icd_code
             AND diag.icd_version = icd.icd_version
         LEFT JOIN fhir_etl.uuid_namespace ns_encounter 

--- a/sql/fhir_condition_ed.sql
+++ b/sql/fhir_condition_ed.sql
@@ -20,7 +20,7 @@ WITH fhir_condition_ed AS (
         , uuid_generate_v5(ns_encounter.uuid, CAST(diag.stay_id AS TEXT)) as uuid_STAY_ID
     FROM
         mimic_ed.diagnosis diag
-        INNER JOIN mimic_hosp.patients pat
+        INNER JOIN mimiciv_hosp.patients pat
             ON diag.subject_id = pat.subject_id
         LEFT JOIN fhir_etl.uuid_namespace ns_encounter 
             ON ns_encounter.name = 'EncounterED'

--- a/sql/fhir_condition_ed.sql
+++ b/sql/fhir_condition_ed.sql
@@ -19,7 +19,7 @@ WITH fhir_condition_ed AS (
         , uuid_generate_v5(ns_patient.uuid, CAST(diag.subject_id AS TEXT)) as uuid_SUBJECT_ID
         , uuid_generate_v5(ns_encounter.uuid, CAST(diag.stay_id AS TEXT)) as uuid_STAY_ID
     FROM
-        mimic_ed.diagnosis diag
+        mimiciv_ed.diagnosis diag
         INNER JOIN mimiciv_hosp.patients pat
             ON diag.subject_id = pat.subject_id
         LEFT JOIN fhir_etl.uuid_namespace ns_encounter 

--- a/sql/fhir_encounter.sql
+++ b/sql/fhir_encounter.sql
@@ -19,7 +19,7 @@ WITH transfer_locations AS (
             )
         ORDER BY intime) AS location_array
     FROM 
-        mimic_hosp.transfers tfr 
+        mimiciv_hosp.transfers tfr 
         LEFT JOIN fhir_etl.uuid_namespace ns_location
             ON ns_location.name = 'Location'
     WHERE tfr.careunit IS NOT NULL 
@@ -37,8 +37,8 @@ WITH transfer_locations AS (
             )
         ) AS cpt_ARRAY
     FROM 
-        mimic_hosp.admissions adm
-        LEFT JOIN mimic_hosp.hcpcsevents cpt
+        mimiciv_hosp.admissions adm
+        LEFT JOIN mimiciv_hosp.hcpcsevents cpt
             ON adm.hadm_id = cpt.hadm_id
     WHERE cpt.hcpcs_cd IS NOT NULL 
     GROUP BY adm.hadm_id     
@@ -48,7 +48,7 @@ WITH transfer_locations AS (
             hadm_id
             , curr_service
             , ROW_NUMBER() OVER (PARTITION BY hadm_id ORDER BY transfertime ASC) row_num
-        FROM mimic_hosp.services s 
+        FROM mimiciv_hosp.services s 
     )
     SELECT 
         hadm_id
@@ -75,7 +75,7 @@ WITH transfer_locations AS (
         , uuid_generate_v5(ns_patient.uuid, CAST(adm.subject_id AS TEXT)) AS uuid_SUBJECT_ID
         , uuid_generate_v5(ns_organization.uuid, 'http://hl7.org/fhir/sid/us-npi/1194052720') AS uuid_ORG
     FROM 
-        mimic_hosp.admissions adm
+        mimiciv_hosp.admissions adm
         LEFT JOIN transfer_locations tfr
             ON adm.hadm_id = tfr.hadm_id
         LEFT JOIN cpt_codes cpt

--- a/sql/fhir_encounter_ed.sql
+++ b/sql/fhir_encounter_ed.sql
@@ -18,7 +18,7 @@ WITH fhir_encounter_ed AS (
         , uuid_generate_v5(ns_patient.uuid, CAST(ed.subject_id AS TEXT)) AS uuid_SUBJECT_ID
         , uuid_generate_v5(ns_organization.uuid, 'http://hl7.org/fhir/sid/us-npi/1194052720') AS uuid_ORG
     FROM 
-        mimic_ed.edstays ed
+        mimiciv_ed.edstays ed
         INNER JOIN mimiciv_hosp.patients pat
             ON ed.subject_id = pat.subject_id
         LEFT JOIN fhir_etl.uuid_namespace ns_encounter	

--- a/sql/fhir_encounter_ed.sql
+++ b/sql/fhir_encounter_ed.sql
@@ -19,7 +19,7 @@ WITH fhir_encounter_ed AS (
         , uuid_generate_v5(ns_organization.uuid, 'http://hl7.org/fhir/sid/us-npi/1194052720') AS uuid_ORG
     FROM 
         mimic_ed.edstays ed
-        INNER JOIN mimic_hosp.patients pat
+        INNER JOIN mimiciv_hosp.patients pat
             ON ed.subject_id = pat.subject_id
         LEFT JOIN fhir_etl.uuid_namespace ns_encounter	
             ON ns_encounter.name = 'Encounter'

--- a/sql/fhir_encounter_icu.sql
+++ b/sql/fhir_encounter_icu.sql
@@ -13,13 +13,13 @@ WITH transfer_location AS (
         , min(icu.first_careunit) AS first_careunit 
         , min(icu.last_careunit) AS last_careunit
     FROM 
-        mimic_icu.icustays icu
-        LEFT JOIN mimic_hosp.transfers tfr_first
+        mimiciv_icu.icustays icu
+        LEFT JOIN mimiciv_hosp.transfers tfr_first
             ON icu.hadm_id = tfr_first.hadm_id 
             AND icu.first_careunit = tfr_first.careunit 
             AND tfr_first.intime >= icu.intime
             AND tfr_first.outtime <= icu.outtime 
-        LEFT JOIN mimic_hosp.transfers tfr_last
+        LEFT JOIN mimiciv_hosp.transfers tfr_last
             ON icu.hadm_id = tfr_last.hadm_id 
             AND icu.last_careunit = tfr_last.careunit 
             AND tfr_last.intime >=  icu.intime
@@ -46,7 +46,7 @@ WITH transfer_location AS (
         , uuid_generate_v5(ns_patient.uuid, CAST(icu.subject_id AS TEXT)) AS uuid_SUBJECT_ID
         
     FROM 
-        mimic_icu.icustays icu        
+        mimiciv_icu.icustays icu        
         -- join transfers to get timing in each careunit
         LEFT JOIN transfer_location tfr
             ON icu.stay_id = tfr.stay_id

--- a/sql/fhir_etl/subjects.sql
+++ b/sql/fhir_etl/subjects.sql
@@ -8,8 +8,8 @@ INSERT INTO fhir_etl.subjects(subject_id)
 SELECT   
     pat.subject_id
 FROM  
-    mimic_hosp.patients pat
-    INNER JOIN mimic_icu.icustays ie 
+    mimiciv_hosp.patients pat
+    INNER JOIN mimiciv_icu.icustays ie 
         ON pat.subject_id = ie.subject_id
 WHERE  
     anchor_age > 0

--- a/sql/fhir_location.sql
+++ b/sql/fhir_location.sql
@@ -13,7 +13,7 @@ WITH fhir_location AS (
         , uuid_generate_v5(ns_location.uuid, careunit) AS uuid_CAREUNIT 
         , uuid_generate_v5(ns_organization.uuid, 'http://hl7.org/fhir/sid/us-npi/1194052720') AS bidmc_UUID
     FROM
-        mimic_hosp.transfers tfr
+        mimiciv_hosp.transfers tfr
         LEFT JOIN fhir_etl.uuid_namespace ns_location
             ON ns_location.name = 'Location'
         LEFT JOIN fhir_etl.uuid_namespace ns_organization

--- a/sql/fhir_medication_administration.sql
+++ b/sql/fhir_medication_administration.sql
@@ -12,7 +12,7 @@ SELECT fhir_etl.fn_create_table_patient_dependent('medication_administration');
 --    4) if nothing is present then store as Unknown medication
 WITH prescriptions AS (
     SELECT DISTINCT pharmacy_id 
-    FROM mimic_hosp.prescriptions 
+    FROM mimiciv_hosp.prescriptions 
 ), emar_detail_unique AS (
     SELECT DISTINCT 
         emar_id
@@ -28,7 +28,7 @@ WITH prescriptions AS (
         , MAX(product_code) AS product_code
         , MAX(pharmacy_id) AS pharmacy_id
     FROM
-        mimic_hosp.emar_detail
+        mimiciv_hosp.emar_detail
     GROUP BY
         emar_id
         , parent_field_ordinal
@@ -116,9 +116,9 @@ WITH prescriptions AS (
         
     FROM
         emar_detail_unique emd
-        LEFT JOIN mimic_hosp.emar em
+        LEFT JOIN mimiciv_hosp.emar em
             ON emd.emar_id = em.emar_id
-        LEFT JOIN mimic_hosp.poe poe
+        LEFT JOIN mimiciv_hosp.poe poe
             ON em.poe_id = poe.poe_id 
         LEFT JOIN prescriptions pr
             ON emd.pharmacy_id = pr.pharmacy_id

--- a/sql/fhir_medication_administration_icu.sql
+++ b/sql/fhir_medication_administration_icu.sql
@@ -22,8 +22,8 @@ WITH fhir_medication_administration_icu AS (
         , uuid_generate_v5(ns_patient.uuid, CAST(ie.subject_id AS TEXT)) AS uuid_SUBJECT_ID
         , uuid_generate_v5(ns_encounter_icu.uuid, CAST(ie.stay_id AS TEXT)) AS uuid_STAY_ID
     FROM
-        mimic_icu.inputevents ie
-        LEFT JOIN mimic_icu.d_items di
+        mimiciv_icu.inputevents ie
+        LEFT JOIN mimiciv_icu.d_items di
             ON ie.itemid = di.itemid
         LEFT JOIN fhir_etl.uuid_namespace ns_encounter_icu
             ON ns_encounter_icu.name = 'EncounterICU'

--- a/sql/fhir_medication_dispense.sql
+++ b/sql/fhir_medication_dispense.sql
@@ -8,7 +8,7 @@ SELECT fhir_etl.fn_create_table_patient_dependent('medication_dispense');
 
 WITH distinct_prescriptions AS (
     SELECT DISTINCT pharmacy_id
-    FROM mimic_hosp.prescriptions 
+    FROM mimiciv_hosp.prescriptions 
 )
 -- Collect all pharmacy_id in pharmacy. 
 -- There are some pharmacy_id in prescriptions that will not have a related pharmacy_id in pharmacy
@@ -45,7 +45,7 @@ WITH distinct_prescriptions AS (
         , uuid_generate_v5(ns_patient.uuid, CAST(ph.subject_id AS TEXT)) AS uuid_SUBJECT_ID
         , uuid_generate_v5(ns_encounter.uuid, CAST(ph.hadm_id AS TEXT)) AS uuid_HADM_ID
     FROM 
-        mimic_hosp.pharmacy ph 
+        mimiciv_hosp.pharmacy ph 
         LEFT JOIN distinct_prescriptions pr
             ON ph.pharmacy_id = pr.pharmacy_id
             

--- a/sql/fhir_medication_dispense_ed.sql
+++ b/sql/fhir_medication_dispense_ed.sql
@@ -18,7 +18,7 @@ WITH fhir_medication_dispense_ed AS (
         , uuid_generate_v5(ns_encounter.uuid, CAST(py.stay_id AS TEXT)) AS uuid_STAY_ID
     FROM 
         mimic_ed.pyxis py  
-        INNER JOIN mimic_hosp.patients pat
+        INNER JOIN mimiciv_hosp.patients pat
             ON py.subject_id = pat.subject_id
         -- UUID namespaces
         LEFT JOIN fhir_etl.uuid_namespace ns_encounter

--- a/sql/fhir_medication_dispense_ed.sql
+++ b/sql/fhir_medication_dispense_ed.sql
@@ -17,7 +17,7 @@ WITH fhir_medication_dispense_ed AS (
         , uuid_generate_v5(ns_patient.uuid, CAST(py.subject_id AS TEXT)) AS uuid_SUBJECT_ID
         , uuid_generate_v5(ns_encounter.uuid, CAST(py.stay_id AS TEXT)) AS uuid_STAY_ID
     FROM 
-        mimic_ed.pyxis py  
+        mimiciv_ed.pyxis py  
         INNER JOIN mimiciv_hosp.patients pat
             ON py.subject_id = pat.subject_id
         -- UUID namespaces

--- a/sql/fhir_medication_request.sql
+++ b/sql/fhir_medication_request.sql
@@ -33,7 +33,7 @@ WITH prescript_request AS (
             , '_' ORDER BY pr.drug_type DESC, pr.drug ASC
         ) AS drug_code  
     FROM 
-        mimic_hosp.prescriptions pr
+        mimiciv_hosp.prescriptions pr
     GROUP BY pr.pharmacy_id 
 ), fhir_medication_request AS (
 	SELECT
@@ -78,7 +78,7 @@ WITH prescript_request AS (
   		, uuid_generate_v5(ns_encounter.uuid, CAST(pr.hadm_id AS TEXT)) AS uuid_HADM_ID
   	FROM
   	    prescript_request pr
-  	    LEFT JOIN mimic_hosp.pharmacy ph
+  	    LEFT JOIN mimiciv_hosp.pharmacy ph
             ON pr.pharmacy_id = ph.pharmacy_id  
   		LEFT JOIN fhir_etl.uuid_namespace ns_encounter
   			ON ns_encounter.name = 'Encounter'
@@ -187,17 +187,17 @@ FROM
 
 -- get unique poe_id that show up in emar, without pharmacy_id and with medication or poe iv order
 WITH prescriptions AS (
-    SELECT DISTINCT pharmacy_id FROM mimic_hosp.prescriptions 
+    SELECT DISTINCT pharmacy_id FROM mimiciv_hosp.prescriptions 
 ), poe_medreq AS (
     SELECT DISTINCT 
         em.poe_id
         , em.medication
         , poe.order_type 
     FROM 
-        mimic_hosp.emar em
+        mimiciv_hosp.emar em
         LEFT JOIN prescriptions pr
             ON em.pharmacy_id = pr.pharmacy_id
-        LEFT JOIN mimic_hosp.poe
+        LEFT JOIN mimiciv_hosp.poe
             ON em.poe_id = poe.poe_id
     WHERE 
         pr.pharmacy_id IS NULL
@@ -229,7 +229,7 @@ WITH prescriptions AS (
         , uuid_generate_v5(ns_encounter.uuid, CAST(poe.hadm_id AS TEXT)) AS uuid_HADM_ID
     FROM
         poe_medreq pm
-        INNER JOIN mimic_hosp.poe poe
+        INNER JOIN mimiciv_hosp.poe poe
             ON pm.poe_id = poe.poe_id
         
         -- uuid namespaces

--- a/sql/fhir_medication_statement_ed.sql
+++ b/sql/fhir_medication_statement_ed.sql
@@ -28,7 +28,7 @@ WITH fhir_medication_statement_ed AS (
         , uuid_generate_v5(ns_patient.uuid, CAST(MAX(med.subject_id) AS TEXT)) AS uuid_SUBJECT_ID
         , uuid_generate_v5(ns_encounter.uuid, CAST(med.stay_id AS TEXT)) AS uuid_STAY_ID
     FROM 
-        mimic_ed.medrecon med
+        mimiciv_ed.medrecon med
         INNER JOIN mimiciv_hosp.patients pat
             ON med.subject_id = pat.subject_id
         

--- a/sql/fhir_medication_statement_ed.sql
+++ b/sql/fhir_medication_statement_ed.sql
@@ -29,7 +29,7 @@ WITH fhir_medication_statement_ed AS (
         , uuid_generate_v5(ns_encounter.uuid, CAST(med.stay_id AS TEXT)) AS uuid_STAY_ID
     FROM 
         mimic_ed.medrecon med
-        INNER JOIN mimic_hosp.patients pat
+        INNER JOIN mimiciv_hosp.patients pat
             ON med.subject_id = pat.subject_id
         
         -- UUID namespaces

--- a/sql/fhir_observation_chartevents.sql
+++ b/sql/fhir_observation_chartevents.sql
@@ -22,8 +22,8 @@ WITH fhir_observation_ce as (
         , uuid_generate_v5(ns_patient.uuid, CAST(ce.subject_id AS text)) AS uuid_SUBJECT_ID
         , uuid_generate_v5(ns_encounter_icu.uuid, CAST(ce.stay_id AS text)) AS uuid_STAY_ID
     FROM
-        mimic_icu.chartevents ce
-        LEFT JOIN mimic_icu.d_items di
+        mimiciv_icu.chartevents ce
+        LEFT JOIN mimiciv_icu.d_items di
             ON ce.itemid = di.itemid
         LEFT JOIN fhir_etl.uuid_namespace ns_encounter_icu
             ON ns_encounter_icu.name = 'EncounterICU'

--- a/sql/fhir_observation_datetimeevents.sql
+++ b/sql/fhir_observation_datetimeevents.sql
@@ -17,8 +17,8 @@ WITH fhir_observation_de AS (
         , uuid_generate_v5(ns_patient.uuid, CAST(de.subject_id AS TEXT)) AS uuid_SUBJECT_ID
         , uuid_generate_v5(ns_encounter_icu.uuid, CAST(de.stay_id AS TEXT)) AS uuid_STAY_ID
     FROM
-        mimic_icu.datetimeevents de
-        LEFT JOIN mimic_icu.d_items di
+        mimiciv_icu.datetimeevents de
+        LEFT JOIN mimiciv_icu.d_items di
             ON de.itemid = di.itemid
         LEFT JOIN fhir_etl.uuid_namespace ns_encounter_icu
             ON ns_encounter_icu.name = 'EncounterICU'

--- a/sql/fhir_observation_ed.sql
+++ b/sql/fhir_observation_ed.sql
@@ -25,7 +25,7 @@ WITH observation_ed AS (
         , uuid_generate_v5(ns_procedure.uuid, ed.stay_id || '-' || ed.charttime) AS uuid_PROCEDURE
     FROM
         observation_ed ed
-        INNER JOIN mimic_hosp.patients pat
+        INNER JOIN mimiciv_hosp.patients pat
             ON ed.subject_id = pat.subject_id
         LEFT JOIN fhir_etl.uuid_namespace ns_encounter_ed
             ON ns_encounter_ed.name = 'EncounterED'
@@ -119,7 +119,7 @@ WITH observation_ed AS (
         , uuid_generate_v5(ns_procedure.uuid, CAST(ed.stay_id AS TEXT)) AS uuid_PROCEDURE
     FROM
         observation_ed ed
-        INNER JOIN mimic_hosp.patients pat
+        INNER JOIN mimiciv_hosp.patients pat
             ON ed.subject_id = pat.subject_id
         LEFT JOIN mimic_ed.edstays stay
             ON ed.stay_id =  stay.stay_id

--- a/sql/fhir_observation_ed.sql
+++ b/sql/fhir_observation_ed.sql
@@ -10,7 +10,7 @@ WITH observation_ed AS (
         , vs.stay_id
         , vs.charttime
         , x.*
-    FROM mimic_ed.vitalsign vs, jsonb_each_text(to_jsonb(vs)) AS x("key", value)
+    FROM mimiciv_ed.vitalsign vs, jsonb_each_text(to_jsonb(vs)) AS x("key", value)
     WHERE KEY IN ('rhythm', 'pain' ) 
 ), fhir_observation_ed AS (
     SELECT
@@ -104,7 +104,7 @@ WITH observation_ed AS (
         tr.subject_id
         , tr.stay_id
         , x.*
-    FROM mimic_ed.triage tr, jsonb_each_text(to_jsonb(tr)) AS x("key", value)
+    FROM mimiciv_ed.triage tr, jsonb_each_text(to_jsonb(tr)) AS x("key", value)
     WHERE KEY IN ('pain', 'acuity', 'chiefcomplaint' ) 
 ), fhir_observation_ed AS (
     SELECT
@@ -121,7 +121,7 @@ WITH observation_ed AS (
         observation_ed ed
         INNER JOIN mimiciv_hosp.patients pat
             ON ed.subject_id = pat.subject_id
-        LEFT JOIN mimic_ed.edstays stay
+        LEFT JOIN mimiciv_ed.edstays stay
             ON ed.stay_id =  stay.stay_id
         LEFT JOIN fhir_etl.uuid_namespace ns_encounter_ed
             ON ns_encounter_ed.name = 'EncounterED'

--- a/sql/fhir_observation_labevents.sql
+++ b/sql/fhir_observation_labevents.sql
@@ -64,8 +64,8 @@ WITH fhir_observation_labevents AS (
         , uuid_generate_v5(ns_encounter.uuid, CAST(lab.hadm_id AS TEXT)) AS uuid_HADM_ID
         , uuid_generate_v5(ns_specimen.uuid, CAST(lab.specimen_id AS TEXT)) AS uuid_SPECIMEN_ID
     FROM
-        mimic_hosp.labevents lab
-        LEFT JOIN mimic_hosp.d_labitems dlab
+        mimiciv_hosp.labevents lab
+        LEFT JOIN mimiciv_hosp.d_labitems dlab
             ON lab.itemid = dlab.itemid                             
         LEFT JOIN fhir_etl.uuid_namespace ns_encounter
             ON ns_encounter.name = 'Encounter'

--- a/sql/fhir_observation_micro_org.sql
+++ b/sql/fhir_observation_micro_org.sql
@@ -25,7 +25,7 @@ WITH micro_info AS (
                 )
             END as fhir_SUSCEPTIBILITY
     FROM 
-        mimic_hosp.microbiologyevents mi
+        mimiciv_hosp.microbiologyevents mi
         LEFT JOIN fhir_etl.uuid_namespace ns_observation_micro_susc
             ON ns_observation_micro_susc.name = 'ObservationMicroSusc'
     WHERE

--- a/sql/fhir_observation_micro_susc.sql
+++ b/sql/fhir_observation_micro_susc.sql
@@ -26,7 +26,7 @@ WITH fhir_observation_micro_susc AS (
         , uuid_generate_v5(ns_observation_micro_org.uuid, mi.test_itemid || '-' || mi.micro_specimen_id || '-' || mi.org_itemid) AS uuid_MICRO_ORG
         , uuid_generate_v5(ns_patient.uuid, CAST(mi.subject_id AS TEXT)) as uuid_SUBJECT_ID 
     FROM 
-        mimic_hosp.microbiologyevents mi
+        mimiciv_hosp.microbiologyevents mi
         LEFT JOIN fhir_etl.uuid_namespace ns_patient
             ON ns_patient.name = 'Patient'
         LEFT JOIN fhir_etl.uuid_namespace ns_observation_micro_org

--- a/sql/fhir_observation_micro_test.sql
+++ b/sql/fhir_observation_micro_test.sql
@@ -39,7 +39,7 @@ WITH distinct_org AS (
         END AS valueCodeableConcept
         
     FROM 
-        mimic_hosp.microbiologyevents mi
+        mimiciv_hosp.microbiologyevents mi
     GROUP BY 
         test_itemid
         , micro_specimen_id

--- a/sql/fhir_observation_outputevents.sql
+++ b/sql/fhir_observation_outputevents.sql
@@ -18,8 +18,8 @@ WITH fhir_observation_oe AS (
         , uuid_generate_v5(ns_patient.uuid, CAST(oe.subject_id AS TEXT)) AS uuid_SUBJECT_ID
         , uuid_generate_v5(ns_encounter_icu.uuid, CAST(oe.stay_id AS TEXT)) AS uuid_STAY_ID
     FROM
-        mimic_icu.outputevents oe
-        LEFT JOIN mimic_icu.d_items di
+        mimiciv_icu.outputevents oe
+        LEFT JOIN mimiciv_icu.d_items di
             ON oe.itemid = di.itemid
         LEFT JOIN fhir_etl.uuid_namespace ns_encounter_icu
             ON ns_encounter_icu.name = 'EncounterICU'

--- a/sql/fhir_observation_vitalsigns.sql
+++ b/sql/fhir_observation_vitalsigns.sql
@@ -11,7 +11,7 @@ WITH vital_signs AS (
         , vs.charttime
         , x.*
         , vs.sbp
-    FROM mimic_ed.vitalsign vs, jsonb_each_text(to_jsonb(vs)) AS x("key", value)
+    FROM mimiciv_ed.vitalsign vs, jsonb_each_text(to_jsonb(vs)) AS x("key", value)
     WHERE KEY IN ('dbp', 'o2sat', 'resprate', 'heartrate', 'temperature') -- rhythm excluded FOR now (stored in MimicObservationED)
 ), fhir_observation_vs AS (
     SELECT
@@ -192,7 +192,7 @@ WITH triage_vital_signs AS (
         , x.*
         , tr.sbp
     FROM 
-        mimic_ed.triage tr, jsonb_each_text(to_jsonb(tr)) AS x("key", value)
+        mimiciv_ed.triage tr, jsonb_each_text(to_jsonb(tr)) AS x("key", value)
     WHERE KEY IN ('dbp', 'o2sat', 'resprate', 'heartrate', 'temperature') -- pain/rhythm excluded FOR now (stored in MimicObservationED)
 ), fhir_observation_vs AS (
     SELECT
@@ -210,7 +210,7 @@ WITH triage_vital_signs AS (
         triage_vital_signs vs
         INNER JOIN mimiciv_hosp.patients pat
             ON vs.subject_id = pat.subject_id
-        LEFT JOIN mimic_ed.edstays ed 
+        LEFT JOIN mimiciv_ed.edstays ed 
             ON vs.stay_id = ed.stay_id
         LEFT JOIN fhir_etl.uuid_namespace ns_encounter_ed
             ON ns_encounter_ed.name = 'EncounterED'

--- a/sql/fhir_observation_vitalsigns.sql
+++ b/sql/fhir_observation_vitalsigns.sql
@@ -27,7 +27,7 @@ WITH vital_signs AS (
         , uuid_generate_v5(ns_procedure.uuid, vs.stay_id || '-' || vs.charttime) AS uuid_PROCEDURE
     FROM
         vital_signs vs
-        INNER JOIN mimic_hosp.patients pat
+        INNER JOIN mimiciv_hosp.patients pat
             ON vs.subject_id = pat.subject_id
         LEFT JOIN fhir_etl.uuid_namespace ns_encounter_ed
             ON ns_encounter_ed.name = 'EncounterED'
@@ -208,7 +208,7 @@ WITH triage_vital_signs AS (
         , uuid_generate_v5(ns_procedure.uuid, CAST(vs.stay_id AS TEXT)) AS uuid_PROCEDURE
     FROM
         triage_vital_signs vs
-        INNER JOIN mimic_hosp.patients pat
+        INNER JOIN mimiciv_hosp.patients pat
             ON vs.subject_id = pat.subject_id
         LEFT JOIN mimic_ed.edstays ed 
             ON vs.stay_id = ed.stay_id

--- a/sql/fhir_patient.sql
+++ b/sql/fhir_patient.sql
@@ -17,15 +17,15 @@ WITH tb_admissions AS (
         , MIN(adm.ethnicity) AS adm_ETHNICITY
         , MIN(adm.language) AS adm_LANGUAGE
     FROM  
-        mimic_hosp.patients pat
-        INNER JOIN mimic_hosp.transfers tfs
+        mimiciv_hosp.patients pat
+        INNER JOIN mimiciv_hosp.transfers tfs
             ON pat.subject_id = tfs.subject_id
         -- Grab latest admittime to get the latest demographic info 
         LEFT JOIN (SELECT subject_id, MAX(admittime) AS admittime
-            FROM mimic_hosp.admissions
+            FROM mimiciv_hosp.admissions
                 GROUP BY subject_id) adm_max
             ON pat.subject_id = adm_max.subject_id
-        LEFT JOIN mimic_hosp.admissions adm
+        LEFT JOIN mimiciv_hosp.admissions adm
             ON adm_max.subject_id = adm.subject_id 
             AND adm_max.admittime = adm.admittime
     GROUP BY 
@@ -61,7 +61,7 @@ WITH tb_admissions AS (
           ELSE NULL END as adm_LANGUAGE
         , uuid_generate_v5(ns_organization.uuid, 'http://hl7.org/fhir/sid/us-npi/1194052720') AS  UUID_organization
     FROM  
-        mimic_hosp.patients pat
+        mimiciv_hosp.patients pat
         LEFT JOIN tb_admissions adm
             ON pat.subject_id = adm.subject_id
         LEFT JOIN ed_race ed

--- a/sql/fhir_procedure.sql
+++ b/sql/fhir_procedure.sql
@@ -19,8 +19,8 @@ WITH fhir_procedure AS (
         , uuid_generate_v5(ns_patient.uuid, CAST(proc.subject_id AS TEXT)) AS uuid_SUBJECT_ID
         , uuid_generate_v5(ns_encounter.uuid, CAST(proc.hadm_id AS TEXT)) AS uuid_HADM_ID
     FROM
-        mimic_hosp.procedures_icd proc
-        LEFT JOIN mimic_hosp.d_icd_procedures icd
+        mimiciv_hosp.procedures_icd proc
+        LEFT JOIN mimiciv_hosp.d_icd_procedures icd
             ON proc.icd_code = icd.icd_code
             AND proc.icd_version = icd.icd_version
         LEFT JOIN fhir_etl.uuid_namespace ns_encounter

--- a/sql/fhir_procedure_ed.sql
+++ b/sql/fhir_procedure_ed.sql
@@ -13,10 +13,10 @@ WITH fhir_procedure_triage AS (
         , uuid_generate_v5(ns_patient.uuid, CAST(proc.subject_id AS TEXT)) AS uuid_SUBJECT_ID
         , uuid_generate_v5(ns_encounter.uuid, CAST(proc.stay_id AS TEXT)) AS uuid_STAY_ID
     FROM
-        mimic_ed.triage proc
+        mimiciv_ed.triage proc
         INNER JOIN mimiciv_hosp.patients pat
             ON proc.subject_id = pat.subject_id
-        LEFT JOIN mimic_ed.edstays stay
+        LEFT JOIN mimiciv_ed.edstays stay
             ON proc.stay_id = stay.stay_id
         LEFT JOIN fhir_etl.uuid_namespace ns_encounter
             ON ns_encounter.name = 'EncounterED'
@@ -63,7 +63,7 @@ WITH fhir_procedure_vitalsign AS (
         , uuid_generate_v5(ns_patient.uuid, CAST(proc.subject_id AS TEXT)) AS uuid_SUBJECT_ID
         , uuid_generate_v5(ns_encounter.uuid, CAST(proc.stay_id AS TEXT)) AS uuid_STAY_ID
     FROM
-        mimic_ed.vitalsign proc
+        mimiciv_ed.vitalsign proc
         INNER JOIN mimiciv_hosp.patients pat
             ON proc.subject_id = pat.subject_id
         LEFT JOIN fhir_etl.uuid_namespace ns_encounter

--- a/sql/fhir_procedure_ed.sql
+++ b/sql/fhir_procedure_ed.sql
@@ -14,7 +14,7 @@ WITH fhir_procedure_triage AS (
         , uuid_generate_v5(ns_encounter.uuid, CAST(proc.stay_id AS TEXT)) AS uuid_STAY_ID
     FROM
         mimic_ed.triage proc
-        INNER JOIN mimic_hosp.patients pat
+        INNER JOIN mimiciv_hosp.patients pat
             ON proc.subject_id = pat.subject_id
         LEFT JOIN mimic_ed.edstays stay
             ON proc.stay_id = stay.stay_id
@@ -64,7 +64,7 @@ WITH fhir_procedure_vitalsign AS (
         , uuid_generate_v5(ns_encounter.uuid, CAST(proc.stay_id AS TEXT)) AS uuid_STAY_ID
     FROM
         mimic_ed.vitalsign proc
-        INNER JOIN mimic_hosp.patients pat
+        INNER JOIN mimiciv_hosp.patients pat
             ON proc.subject_id = pat.subject_id
         LEFT JOIN fhir_etl.uuid_namespace ns_encounter
             ON ns_encounter.name = 'EncounterED'

--- a/sql/fhir_procedure_icu.sql
+++ b/sql/fhir_procedure_icu.sql
@@ -18,8 +18,8 @@ WITH fhir_procedure_icu AS (
         , uuid_generate_v5(ns_patient.uuid, CAST(pe.subject_id AS TEXT)) AS uuid_SUBJECT_ID
         , uuid_generate_v5(ns_encounter_icu.uuid, CAST(pe.stay_id AS TEXT)) AS uuid_STAY_ID
     FROM
-        mimic_icu.procedureevents pe
-        LEFT JOIN mimic_icu.d_items di
+        mimiciv_icu.procedureevents pe
+        LEFT JOIN mimiciv_icu.d_items di
             ON pe.itemid = di.itemid
         LEFT JOIN fhir_etl.map_status_procedure_icu map_status
             ON pe.statusdescription = map_status.mimic_status

--- a/sql/fhir_specimen.sql
+++ b/sql/fhir_specimen.sql
@@ -13,7 +13,7 @@ WITH fhir_specimen AS (
         , uuid_generate_v5(ns_specimen.uuid, CAST(mi.micro_specimen_id AS TEXT)) AS uuid_SPECIMEN
         , uuid_generate_v5(ns_patient.uuid, CAST(MAX(mi.subject_id) AS TEXT)) as uuid_SUBJECT_ID
     FROM
-        mimic_hosp.microbiologyevents mi
+        mimiciv_hosp.microbiologyevents mi
         LEFT JOIN fhir_etl.uuid_namespace ns_patient
             ON ns_patient.name = 'Patient'
         LEFT JOIN fhir_etl.uuid_namespace ns_specimen

--- a/sql/fhir_specimen_lab.sql
+++ b/sql/fhir_specimen_lab.sql
@@ -8,7 +8,7 @@ WITH lab AS (
         , MAX(lab.subject_id) AS subject_id
         , MAX(lab.charttime) AS charttime
     FROM 
-        mimic_hosp.labevents lab  
+        mimiciv_hosp.labevents lab  
     GROUP BY
         specimen_id        
 )
@@ -22,7 +22,7 @@ WITH lab AS (
         , uuid_generate_v5(ns_patient.uuid, CAST(lab.subject_id AS TEXT)) as uuid_SUBJECT_ID
     FROM 
         lab
-        LEFT JOIN mimic_hosp.d_labitems dlab
+        LEFT JOIN mimiciv_hosp.d_labitems dlab
             ON lab.itemid = dlab.itemid
         LEFT JOIN fhir_etl.uuid_namespace ns_patient
             ON ns_patient.name = 'Patient'

--- a/sql/medication/medication_mix.sql
+++ b/sql/medication/medication_mix.sql
@@ -22,7 +22,7 @@ WITH medication_identifier AS (
         , drug
         , drug_type
     FROM 
-        mimic_hosp.prescriptions pr
+        mimiciv_hosp.prescriptions pr
 ), medication_mix AS (
     SELECT DISTINCT 
         -- For prescriptions with multiple drugs prescribed, put the drugs under ingredients
@@ -40,7 +40,7 @@ WITH medication_identifier AS (
         -- Multiple additives are allowed, so these are ordered alphabetically 
         , STRING_AGG(mid.med_id, '_' ORDER BY pr.drug_type DESC, pr.drug ASC) AS medmix_id   
     FROM 
-        mimic_hosp.prescriptions pr
+        mimiciv_hosp.prescriptions pr
         LEFT JOIN medication_identifier mid
             ON pr.pharmacy_id = mid.pharmacy_id
             AND pr.drug = mid.drug

--- a/sql/medication/medication_prescriptions.sql
+++ b/sql/medication/medication_prescriptions.sql
@@ -31,7 +31,7 @@ WITH prescriptions_med AS (
                     THEN '--' || ndc ELSE '' END            
         ) AS med_UUID        
     FROM 
-        mimic_hosp.prescriptions pr
+        mimiciv_hosp.prescriptions pr
         LEFT JOIN fhir_etl.uuid_namespace ns_medication
             ON ns_medication.name = 'MedicationPrescriptions'
 )


### PR DESCRIPTION
Main updates include:
- Renaming schemas, adding `mimiciv` prefix (ie mimic_hosp -> mimiciv_hosp)
- Minor changes for macbook running