### PR TITLE
Update SQL script that exports FHIR resources to NDJSON files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,16 @@ psql -d mimiciv -f create_fhir_tables.sql
 psql -d mimiciv -f validate_fhir_tables.sql
 ```
 
+
+#### Export to ndjson files
+
+- Export the FHIR resources to ndjson files in `<output-dir>` by running [create_fhir_jsons.sql](...)  found in the folder `mimic-fhir/sql`
+(replace `<output-dir>` with the desired existing and empty output directory).
+
+```sh
+psql -d mimiciv -v "outputdir=<output-dir>" -f sql/create_fhir_jsons.sql
+````
+
 ## HAPI FHIR for use in validation/export
 
 - The first step in validation/export is getting the fhir server running. In our case we will use HAPI FHIR.

--- a/sql/create_fhir_jsons.sql
+++ b/sql/create_fhir_jsons.sql
@@ -93,6 +93,11 @@ do $$ BEGIN RAISE 'outputdir not set, exiting'; END; $$ LANGUAGE plpgsql;
 \set command '\\copy mimic_fhir.medication_dispense_ed(fhir) TO ' :'outputfile' :with_format
 :command
 
+\echo medication_dispense_mix
+\set outputfile :outputdir/MimicMedicationMix.ndjson
+\set command '\\copy mimic_fhir.medication_mix(fhir) TO ' :'outputfile' :with_format
+:command
+
 \echo medadmin
 \set outputfile :outputdir/MimicMedicationAdministration.ndjson
 \set command '\\copy mimic_fhir.medication_administration(fhir) TO ' :'outputfile' :with_format

--- a/sql/create_fhir_jsons.sql
+++ b/sql/create_fhir_jsons.sql
@@ -150,6 +150,16 @@ do $$ BEGIN RAISE 'outputdir not set, exiting'; END; $$ LANGUAGE plpgsql;
 :command
 
 \echo observation_vitalsigns
-\set outputfile :outputdir/MimicObservationVitalSigns.ndjson
+\set outputfile :outputdir/MimicObservationVitalSignsED.ndjson
 \set command '\\copy mimic_fhir.observation_vital_signs(fhir) TO ' :'outputfile' :with_format
+:command
+
+\echo specimen
+\set outputfile :outputdir/MimicSpecimen.ndjson
+\set command '\\copy mimic_fhir.specimen(fhir) TO ' :'outputfile' :with_format
+:command
+
+\echo specimen_lab
+\set outputfile :outputdir/MimicSpecimenLab.ndjson
+\set command '\\copy mimic_fhir.specimen_lab(fhir) TO ' :'outputfile' :with_format
 :command


### PR DESCRIPTION
This pull requests:
- updates the `sql/create_fhir_jsons.sql` to:
    * include `MimicMedicationMix`, `MimicSpecimen` and `MimicSpecimenLab` resources in the export
    * rename the file for `MimicObservationVitalSigns` to `MimicObservationVitalSignsED` to match the published name in mimic-fhir-1.0 (and the convention as this resource is produced from mimic-ed)

- adds a section on exporting to NDSJON with the sql script in the `README.md`  